### PR TITLE
Switch to FD.O 21.08 runtime and restore removed permission

### DIFF
--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -11,6 +11,7 @@ finish-args:
 - "--socket=wayland"
 - "--filesystem=host"
 - "--device=dri"
+- "--filesystem=~/.var/app"
 build-options:
   append-path: "/usr/lib/sdk/rust-stable/bin"
   env:

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -1,7 +1,7 @@
 app-id: com.github.qarmin.czkawka
-runtime: org.gnome.Platform
-runtime-version: '3.38'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable
 command: czkawka_gui


### PR DESCRIPTION
When I updated Czkawka, I was prompted to reinstall a runtime that was EOL, and had been removed from my system. Commit aef4c9 reverted @TheEvilSkeleton's change that bumped the runtime to version 40, as well as their change that allowed this app to read Flatpak config directories. I think this might have happened as a result of not merging in changes from the remote repository before continuing development.

I've been looking for apps that are unnecessarily targeting the GNOME runtime when they are just using GTK to move them to FreeDesktop anyways, so I thought I'd kill two birds with one stone; get this app off of an EOL runtime, and then also move it to the FreeDesktop runtime since it uses GTK without being particularly GNOME-y. This also restores the removed permission.