### PR TITLE
Update runtime to gnome 44

### DIFF
--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.qarmin.czkawka
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '44'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
```
Info: runtime org.gnome.Platform branch 42 is end-of-life, with reason:
   The GNOME 42 runtime is no longer supported as of March 21, 2023. Please ask your application developer to migrate to a supported platform.
```

I tested all features with default settings.

"Similar Videos" showed `Failed to hash file, reason Too short` for all videos on both builds.
Gnome 42 runtime has ffmpeg 4.3.5, gnome 44 runtime has ffmpeg 5.0.2.

Everything else worked.