### PR TITLE
Add xdg-config permission to fix dark theme

### DIFF
--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -12,6 +12,7 @@ finish-args:
 - "--filesystem=host"
 - "--device=dri"
 - "--filesystem=~/.var/app"
+- "--filesystem=xdg-config/gtk-4.0:ro"
 build-options:
   append-path: "/usr/lib/sdk/rust-stable/bin"
   env:


### PR DESCRIPTION
I noticed that by default this app is not themed correctly on my system. This additional permission should resolve the broken theming on some systems.

Tested on my system:
Theme: Breeze Dark (org.gtk.Gtk3theme.Breeze)
Operating System: Arch Linux
KDE Plasma Version: 5.27.7
KDE Frameworks Version: 5.108.0
Qt Version: 5.15.10
Kernel Version: 6.4.9-arch1-1 (64-bit)
Graphics Platform: Wayland