### PR TITLE
Remove xdg-config access

### DIFF
--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -12,7 +12,6 @@ finish-args:
 - "--filesystem=host"
 - "--device=dri"
 - "--filesystem=~/.var/app"
-- "--filesystem=xdg-config/gtk-4.0:ro"
 build-options:
   append-path: "/usr/lib/sdk/rust-stable/bin"
   env:


### PR DESCRIPTION
This is required for new builds on Flathub and will help get this app updated to 7.0