### PR TITLE
update to 8.0.0, bump runtime and dependencies

### DIFF
--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -2,14 +2,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.28.crate",
-        "sha256": "79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb",
-        "dest": "cargo/vendor/ab_glyph-0.2.28"
+        "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.29.crate",
+        "sha256": "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0",
+        "dest": "cargo/vendor/ab_glyph-0.2.29"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb\", \"files\": {}}",
-        "dest": "cargo/vendor/ab_glyph-0.2.28",
+        "contents": "{\"package\": \"ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0\", \"files\": {}}",
+        "dest": "cargo/vendor/ab_glyph-0.2.29",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -101,6 +101,19 @@
         "type": "inline",
         "contents": "{\"package\": \"8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916\", \"files\": {}}",
         "dest": "cargo/vendor/aho-corasick-1.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aligned-vec/aligned-vec-0.5.0.crate",
+        "sha256": "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1",
+        "dest": "cargo/vendor/aligned-vec-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1\", \"files\": {}}",
+        "dest": "cargo/vendor/aligned-vec-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -249,6 +262,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arbitrary/arbitrary-1.3.2.crate",
+        "sha256": "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110",
+        "dest": "cargo/vendor/arbitrary-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110\", \"files\": {}}",
+        "dest": "cargo/vendor/arbitrary-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/arc-swap/arc-swap-1.7.1.crate",
         "sha256": "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457",
         "dest": "cargo/vendor/arc-swap-1.7.1"
@@ -257,6 +283,19 @@
         "type": "inline",
         "contents": "{\"package\": \"69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457\", \"files\": {}}",
         "dest": "cargo/vendor/arc-swap-1.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arg_enum_proc_macro/arg_enum_proc_macro-0.3.4.crate",
+        "sha256": "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea",
+        "dest": "cargo/vendor/arg_enum_proc_macro-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea\", \"files\": {}}",
+        "dest": "cargo/vendor/arg_enum_proc_macro-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -314,14 +353,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ashpd/ashpd-0.8.1.crate",
-        "sha256": "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093",
-        "dest": "cargo/vendor/ashpd-0.8.1"
+        "url": "https://static.crates.io/crates/ashpd/ashpd-0.9.2.crate",
+        "sha256": "4d43c03d9e36dd40cab48435be0b09646da362c278223ca535493877b2c1dee9",
+        "dest": "cargo/vendor/ashpd-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093\", \"files\": {}}",
-        "dest": "cargo/vendor/ashpd-0.8.1",
+        "contents": "{\"package\": \"4d43c03d9e36dd40cab48435be0b09646da362c278223ca535493877b2c1dee9\", \"files\": {}}",
+        "dest": "cargo/vendor/ashpd-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -535,14 +574,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/base64/base64-0.21.7.crate",
-        "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
-        "dest": "cargo/vendor/base64-0.21.7"
+        "url": "https://static.crates.io/crates/av-data/av-data-0.4.3.crate",
+        "sha256": "124ae24335161b3d2226594640a67903da0866e2591312591fc8ddad64c1b38c",
+        "dest": "cargo/vendor/av-data-0.4.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567\", \"files\": {}}",
-        "dest": "cargo/vendor/base64-0.21.7",
+        "contents": "{\"package\": \"124ae24335161b3d2226594640a67903da0866e2591312591fc8ddad64c1b38c\", \"files\": {}}",
+        "dest": "cargo/vendor/av-data-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/av1-grain/av1-grain-0.2.3.crate",
+        "sha256": "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf",
+        "dest": "cargo/vendor/av1-grain-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf\", \"files\": {}}",
+        "dest": "cargo/vendor/av1-grain-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/avif-serialize/avif-serialize-0.8.1.crate",
+        "sha256": "876c75a42f6364451a033496a14c44bffe41f5f4a8236f697391f11024e596d2",
+        "dest": "cargo/vendor/avif-serialize-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"876c75a42f6364451a033496a14c44bffe41f5f4a8236f697391f11024e596d2\", \"files\": {}}",
+        "dest": "cargo/vendor/avif-serialize-0.8.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -556,19 +621,6 @@
         "type": "inline",
         "contents": "{\"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\", \"files\": {}}",
         "dest": "cargo/vendor/base64-0.22.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/base64ct/base64ct-1.6.0.crate",
-        "sha256": "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b",
-        "dest": "cargo/vendor/base64ct-1.6.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b\", \"files\": {}}",
-        "dest": "cargo/vendor/base64ct-1.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -600,14 +652,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bindgen/bindgen-0.69.4.crate",
-        "sha256": "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0",
-        "dest": "cargo/vendor/bindgen-0.69.4"
+        "url": "https://static.crates.io/crates/bindgen/bindgen-0.69.5.crate",
+        "sha256": "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088",
+        "dest": "cargo/vendor/bindgen-0.69.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0\", \"files\": {}}",
-        "dest": "cargo/vendor/bindgen-0.69.4",
+        "contents": "{\"package\": \"271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088\", \"files\": {}}",
+        "dest": "cargo/vendor/bindgen-0.69.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -647,6 +699,32 @@
         "type": "inline",
         "contents": "{\"package\": \"b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de\", \"files\": {}}",
         "dest": "cargo/vendor/bitflags-2.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitreader/bitreader-0.3.10.crate",
+        "sha256": "b1123451be0f8ada15415fbb4e0fe50775be531f61a432c18168a4f96e470ce1",
+        "dest": "cargo/vendor/bitreader-0.3.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b1123451be0f8ada15415fbb4e0fe50775be531f61a432c18168a4f96e470ce1\", \"files\": {}}",
+        "dest": "cargo/vendor/bitreader-0.3.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitstream-io/bitstream-io-2.5.3.crate",
+        "sha256": "b81e1519b0d82120d2fd469d5bfb2919a9361c48b02d82d04befc1cdd2002452",
+        "dest": "cargo/vendor/bitstream-io-2.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b81e1519b0d82120d2fd469d5bfb2919a9361c48b02d82d04befc1cdd2002452\", \"files\": {}}",
+        "dest": "cargo/vendor/bitstream-io-2.5.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -756,6 +834,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/built/built-0.7.4.crate",
+        "sha256": "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4",
+        "dest": "cargo/vendor/built-0.7.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4\", \"files\": {}}",
+        "dest": "cargo/vendor/built-0.7.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.16.0.crate",
         "sha256": "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c",
         "dest": "cargo/vendor/bumpalo-3.16.0"
@@ -782,6 +873,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/byte-slice-cast/byte-slice-cast-1.2.2.crate",
+        "sha256": "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c",
+        "dest": "cargo/vendor/byte-slice-cast-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c\", \"files\": {}}",
+        "dest": "cargo/vendor/byte-slice-cast-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.18.0.crate",
         "sha256": "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae",
         "dest": "cargo/vendor/bytemuck-1.18.0"
@@ -795,14 +899,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bytemuck_derive/bytemuck_derive-1.7.1.crate",
-        "sha256": "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26",
-        "dest": "cargo/vendor/bytemuck_derive-1.7.1"
+        "url": "https://static.crates.io/crates/bytemuck_derive/bytemuck_derive-1.8.0.crate",
+        "sha256": "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec",
+        "dest": "cargo/vendor/bytemuck_derive-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26\", \"files\": {}}",
-        "dest": "cargo/vendor/bytemuck_derive-1.7.1",
+        "contents": "{\"package\": \"bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck_derive-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -873,27 +977,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.19.4.crate",
-        "sha256": "b2ac2a4d0e69036cf0062976f6efcba1aaee3e448594e6514bb2ddf87acce562",
-        "dest": "cargo/vendor/cairo-rs-0.19.4"
+        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.20.1.crate",
+        "sha256": "e8a0ea147c94108c9613235388f540e4d14c327f7081c9e471fc8ee8a2533e69",
+        "dest": "cargo/vendor/cairo-rs-0.20.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b2ac2a4d0e69036cf0062976f6efcba1aaee3e448594e6514bb2ddf87acce562\", \"files\": {}}",
-        "dest": "cargo/vendor/cairo-rs-0.19.4",
+        "contents": "{\"package\": \"e8a0ea147c94108c9613235388f540e4d14c327f7081c9e471fc8ee8a2533e69\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-rs-0.20.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.19.2.crate",
-        "sha256": "fd3bb3119664efbd78b5e6c93957447944f16bdbced84c17a9f41c7829b81e64",
-        "dest": "cargo/vendor/cairo-sys-rs-0.19.2"
+        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.20.0.crate",
+        "sha256": "428290f914b9b86089f60f5d8a9f6e440508e1bcff23b25afd51502b0a2da88f",
+        "dest": "cargo/vendor/cairo-sys-rs-0.20.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fd3bb3119664efbd78b5e6c93957447944f16bdbced84c17a9f41c7829b81e64\", \"files\": {}}",
-        "dest": "cargo/vendor/cairo-sys-rs-0.19.2",
+        "contents": "{\"package\": \"428290f914b9b86089f60f5d8a9f6e440508e1bcff23b25afd51502b0a2da88f\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-sys-rs-0.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -951,14 +1055,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.1.23.crate",
-        "sha256": "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17",
-        "dest": "cargo/vendor/cc-1.1.23"
+        "url": "https://static.crates.io/crates/cc/cc-1.1.28.crate",
+        "sha256": "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1",
+        "dest": "cargo/vendor/cc-1.1.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.1.23",
+        "contents": "{\"package\": \"2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.1.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1011,6 +1115,19 @@
         "type": "inline",
         "contents": "{\"package\": \"d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02\", \"files\": {}}",
         "dest": "cargo/vendor/cfg-expr-0.15.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.17.0.crate",
+        "sha256": "d0890061c4d3223e7267f3bad2ec40b997d64faac1c2815a4a9d95018e2b9e9c",
+        "dest": "cargo/vendor/cfg-expr-0.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d0890061c4d3223e7267f3bad2ec40b997d64faac1c2815a4a9d95018e2b9e9c\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-expr-0.17.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1094,27 +1211,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap/clap-4.5.18.crate",
-        "sha256": "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3",
-        "dest": "cargo/vendor/clap-4.5.18"
+        "url": "https://static.crates.io/crates/clap/clap-4.5.20.crate",
+        "sha256": "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8",
+        "dest": "cargo/vendor/clap-4.5.20"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3\", \"files\": {}}",
-        "dest": "cargo/vendor/clap-4.5.18",
+        "contents": "{\"package\": \"b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8\", \"files\": {}}",
+        "dest": "cargo/vendor/clap-4.5.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap_builder/clap_builder-4.5.18.crate",
-        "sha256": "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b",
-        "dest": "cargo/vendor/clap_builder-4.5.18"
+        "url": "https://static.crates.io/crates/clap_builder/clap_builder-4.5.20.crate",
+        "sha256": "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54",
+        "dest": "cargo/vendor/clap_builder-4.5.20"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b\", \"files\": {}}",
-        "dest": "cargo/vendor/clap_builder-4.5.18",
+        "contents": "{\"package\": \"19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_builder-4.5.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1323,19 +1440,6 @@
         "type": "inline",
         "contents": "{\"package\": \"373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d\", \"files\": {}}",
         "dest": "cargo/vendor/const_fn-0.4.10",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/constant_time_eq/constant_time_eq-0.1.5.crate",
-        "sha256": "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc",
-        "dest": "cargo/vendor/constant_time_eq-0.1.5"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc\", \"files\": {}}",
-        "dest": "cargo/vendor/constant_time_eq-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1731,14 +1835,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/dashmap/dashmap-5.5.3.crate",
-        "sha256": "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856",
-        "dest": "cargo/vendor/dashmap-5.5.3"
+        "url": "https://static.crates.io/crates/dashmap/dashmap-6.1.0.crate",
+        "sha256": "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf",
+        "dest": "cargo/vendor/dashmap-6.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856\", \"files\": {}}",
-        "dest": "cargo/vendor/dashmap-5.5.3",
+        "contents": "{\"package\": \"5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf\", \"files\": {}}",
+        "dest": "cargo/vendor/dashmap-6.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1796,6 +1900,45 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dav1d/dav1d-0.10.3.crate",
+        "sha256": "0d4b54a40baf633a71c6f0fb49494a7e4ee7bc26f3e727212b6cb915aa1ea1e1",
+        "dest": "cargo/vendor/dav1d-0.10.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0d4b54a40baf633a71c6f0fb49494a7e4ee7bc26f3e727212b6cb915aa1ea1e1\", \"files\": {}}",
+        "dest": "cargo/vendor/dav1d-0.10.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dav1d-sys/dav1d-sys-0.8.2.crate",
+        "sha256": "6ecb1c5e8f4dc438eedc1b534a54672fb0e0a56035dae6b50162787bd2c50e95",
+        "dest": "cargo/vendor/dav1d-sys-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ecb1c5e8f4dc438eedc1b534a54672fb0e0a56035dae6b50162787bd2c50e95\", \"files\": {}}",
+        "dest": "cargo/vendor/dav1d-sys-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dcv-color-primitives/dcv-color-primitives-0.6.1.crate",
+        "sha256": "07ad62edfed069700a5b33af6babd29c498d7e33eb01d96ffa8841ee1841634c",
+        "dest": "cargo/vendor/dcv-color-primitives-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"07ad62edfed069700a5b33af6babd29c498d7e33eb01d96ffa8841ee1841634c\", \"files\": {}}",
+        "dest": "cargo/vendor/dcv-color-primitives-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/deflate/deflate-1.0.0.crate",
         "sha256": "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f",
         "dest": "cargo/vendor/deflate-1.0.0"
@@ -1817,6 +1960,19 @@
         "type": "inline",
         "contents": "{\"package\": \"b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4\", \"files\": {}}",
         "dest": "cargo/vendor/deranged-0.3.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_arbitrary/derive_arbitrary-1.3.2.crate",
+        "sha256": "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611",
+        "dest": "cargo/vendor/derive_arbitrary-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_arbitrary-1.3.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2017,14 +2173,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/dwrote/dwrote-0.11.1.crate",
-        "sha256": "2da3498378ed373237bdef1eddcc64e7be2d3ba4841f4c22a998e81cadeea83c",
-        "dest": "cargo/vendor/dwrote-0.11.1"
+        "url": "https://static.crates.io/crates/dwrote/dwrote-0.11.2.crate",
+        "sha256": "70182709525a3632b2ba96b6569225467b18ecb4a77f46d255f713a6bebf05fd",
+        "dest": "cargo/vendor/dwrote-0.11.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2da3498378ed373237bdef1eddcc64e7be2d3ba4841f4c22a998e81cadeea83c\", \"files\": {}}",
-        "dest": "cargo/vendor/dwrote-0.11.1",
+        "contents": "{\"package\": \"70182709525a3632b2ba96b6569225467b18ecb4a77f46d255f713a6bebf05fd\", \"files\": {}}",
+        "dest": "cargo/vendor/dwrote-0.11.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2212,6 +2368,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fallible_collections/fallible_collections-0.4.9.crate",
+        "sha256": "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd",
+        "dest": "cargo/vendor/fallible_collections-0.4.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd\", \"files\": {}}",
+        "dest": "cargo/vendor/fallible_collections-0.4.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fastrand/fastrand-2.1.1.crate",
         "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
         "dest": "cargo/vendor/fastrand-2.1.1"
@@ -2298,6 +2467,19 @@
         "type": "inline",
         "contents": "{\"package\": \"38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f\", \"files\": {}}",
         "dest": "cargo/vendor/field-offset-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/file-id/file-id-0.2.1.crate",
+        "sha256": "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9",
+        "dest": "cargo/vendor/file-id-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9\", \"files\": {}}",
+        "dest": "cargo/vendor/file-id-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2576,53 +2758,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.30.crate",
-        "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
-        "dest": "cargo/vendor/futures-channel-0.3.30"
+        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.31.crate",
+        "sha256": "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10",
+        "dest": "cargo/vendor/futures-channel-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-channel-0.3.30",
+        "contents": "{\"package\": \"2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-channel-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.30.crate",
-        "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
-        "dest": "cargo/vendor/futures-core-0.3.30"
+        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.31.crate",
+        "sha256": "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e",
+        "dest": "cargo/vendor/futures-core-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-core-0.3.30",
+        "contents": "{\"package\": \"05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-core-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.30.crate",
-        "sha256": "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d",
-        "dest": "cargo/vendor/futures-executor-0.3.30"
+        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.31.crate",
+        "sha256": "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f",
+        "dest": "cargo/vendor/futures-executor-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-executor-0.3.30",
+        "contents": "{\"package\": \"1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-executor-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.30.crate",
-        "sha256": "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1",
-        "dest": "cargo/vendor/futures-io-0.3.30"
+        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.31.crate",
+        "sha256": "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6",
+        "dest": "cargo/vendor/futures-io-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-io-0.3.30",
+        "contents": "{\"package\": \"9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-io-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2641,53 +2823,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.30.crate",
-        "sha256": "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac",
-        "dest": "cargo/vendor/futures-macro-0.3.30"
+        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.31.crate",
+        "sha256": "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650",
+        "dest": "cargo/vendor/futures-macro-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-macro-0.3.30",
+        "contents": "{\"package\": \"162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-macro-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.30.crate",
-        "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5",
-        "dest": "cargo/vendor/futures-sink-0.3.30"
+        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.31.crate",
+        "sha256": "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7",
+        "dest": "cargo/vendor/futures-sink-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-sink-0.3.30",
+        "contents": "{\"package\": \"e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-sink-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.30.crate",
-        "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004",
-        "dest": "cargo/vendor/futures-task-0.3.30"
+        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.31.crate",
+        "sha256": "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988",
+        "dest": "cargo/vendor/futures-task-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-task-0.3.30",
+        "contents": "{\"package\": \"f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-task-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.30.crate",
-        "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
-        "dest": "cargo/vendor/futures-util-0.3.30"
+        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.31.crate",
+        "sha256": "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81",
+        "dest": "cargo/vendor/futures-util-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-util-0.3.30",
+        "contents": "{\"package\": \"9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-util-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2719,53 +2901,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.19.8.crate",
-        "sha256": "624eaba126021103c7339b2e179ae4ee8cdab842daab419040710f38ed9f8699",
-        "dest": "cargo/vendor/gdk-pixbuf-0.19.8"
+        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.20.4.crate",
+        "sha256": "c4c29071a9e92337d8270a85cb0510cda4ac478be26d09ad027cc1d081911b19",
+        "dest": "cargo/vendor/gdk-pixbuf-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"624eaba126021103c7339b2e179ae4ee8cdab842daab419040710f38ed9f8699\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk-pixbuf-0.19.8",
+        "contents": "{\"package\": \"c4c29071a9e92337d8270a85cb0510cda4ac478be26d09ad027cc1d081911b19\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.19.8.crate",
-        "sha256": "4efa05a4f83c8cc50eb4d883787b919b85e5f1d8dd10b5a1df53bf5689782379",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.8"
+        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.20.4.crate",
+        "sha256": "687343b059b91df5f3fbd87b4307038fa9e647fcc0461d0d3f93e94fee20bf3d",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4efa05a4f83c8cc50eb4d883787b919b85e5f1d8dd10b5a1df53bf5689782379\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.8",
+        "contents": "{\"package\": \"687343b059b91df5f3fbd87b4307038fa9e647fcc0461d0d3f93e94fee20bf3d\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk4/gdk4-0.8.2.crate",
-        "sha256": "db265c9dd42d6a371e09e52deab3a84808427198b86ac792d75fd35c07990a07",
-        "dest": "cargo/vendor/gdk4-0.8.2"
+        "url": "https://static.crates.io/crates/gdk4/gdk4-0.9.2.crate",
+        "sha256": "c121aeeb0cf7545877ae615dac6bfd088b739d8abee4d55e7143b06927d16a31",
+        "dest": "cargo/vendor/gdk4-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"db265c9dd42d6a371e09e52deab3a84808427198b86ac792d75fd35c07990a07\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk4-0.8.2",
+        "contents": "{\"package\": \"c121aeeb0cf7545877ae615dac6bfd088b739d8abee4d55e7143b06927d16a31\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk4-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.8.2.crate",
-        "sha256": "c9418fb4e8a67074919fe7604429c45aa74eb9df82e7ca529767c6d4e9dc66dd",
-        "dest": "cargo/vendor/gdk4-sys-0.8.2"
+        "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.9.2.crate",
+        "sha256": "7d3c03d1ea9d5199f14f060890fde68a3b5ec5699144773d1fa6abf337bfbc9c",
+        "dest": "cargo/vendor/gdk4-sys-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c9418fb4e8a67074919fe7604429c45aa74eb9df82e7ca529767c6d4e9dc66dd\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk4-sys-0.8.2",
+        "contents": "{\"package\": \"7d3c03d1ea9d5199f14f060890fde68a3b5ec5699144773d1fa6abf337bfbc9c\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk4-sys-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2836,27 +3018,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gio/gio-0.19.8.crate",
-        "sha256": "4c49f117d373ffcc98a35d114db5478bc223341cff53e39a5d6feced9e2ddffe",
-        "dest": "cargo/vendor/gio-0.19.8"
+        "url": "https://static.crates.io/crates/gio/gio-0.20.4.crate",
+        "sha256": "b8d999e8fb09583e96080867e364bc1e701284ad206c76a5af480d63833ad43c",
+        "dest": "cargo/vendor/gio-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4c49f117d373ffcc98a35d114db5478bc223341cff53e39a5d6feced9e2ddffe\", \"files\": {}}",
-        "dest": "cargo/vendor/gio-0.19.8",
+        "contents": "{\"package\": \"b8d999e8fb09583e96080867e364bc1e701284ad206c76a5af480d63833ad43c\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.19.8.crate",
-        "sha256": "2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef",
-        "dest": "cargo/vendor/gio-sys-0.19.8"
+        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.20.4.crate",
+        "sha256": "4f7efc368de04755344f0084104835b6bb71df2c1d41e37d863947392a894779",
+        "dest": "cargo/vendor/gio-sys-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef\", \"files\": {}}",
-        "dest": "cargo/vendor/gio-sys-0.19.8",
+        "contents": "{\"package\": \"4f7efc368de04755344f0084104835b6bb71df2c1d41e37d863947392a894779\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-sys-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2875,40 +3057,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib/glib-0.19.9.crate",
-        "sha256": "39650279f135469465018daae0ba53357942a5212137515777d5fdca74984a44",
-        "dest": "cargo/vendor/glib-0.19.9"
+        "url": "https://static.crates.io/crates/glib/glib-0.20.4.crate",
+        "sha256": "adcf1ec6d3650bf9fdbc6cee242d4fcebc6f6bfd9bea5b929b6a8b7344eb85ff",
+        "dest": "cargo/vendor/glib-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"39650279f135469465018daae0ba53357942a5212137515777d5fdca74984a44\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-0.19.9",
+        "contents": "{\"package\": \"adcf1ec6d3650bf9fdbc6cee242d4fcebc6f6bfd9bea5b929b6a8b7344eb85ff\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.19.9.crate",
-        "sha256": "4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7",
-        "dest": "cargo/vendor/glib-macros-0.19.9"
+        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.20.4.crate",
+        "sha256": "a6bf88f70cd5720a6197639dcabcb378dd528d0cb68cb1f45e3b358bcb841cd7",
+        "dest": "cargo/vendor/glib-macros-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-macros-0.19.9",
+        "contents": "{\"package\": \"a6bf88f70cd5720a6197639dcabcb378dd528d0cb68cb1f45e3b358bcb841cd7\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-macros-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.19.8.crate",
-        "sha256": "5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5",
-        "dest": "cargo/vendor/glib-sys-0.19.8"
+        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.20.4.crate",
+        "sha256": "5f9eca5d88cfa6a453b00d203287c34a2b7cac3a7831779aa2bb0b3c7233752b",
+        "dest": "cargo/vendor/glib-sys-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-sys-0.19.8",
+        "contents": "{\"package\": \"5f9eca5d88cfa6a453b00d203287c34a2b7cac3a7831779aa2bb0b3c7233752b\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-sys-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3018,105 +3200,105 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.19.8.crate",
-        "sha256": "2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e",
-        "dest": "cargo/vendor/gobject-sys-0.19.8"
+        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.20.4.crate",
+        "sha256": "a4c674d2ff8478cf0ec29d2be730ed779fef54415a2fb4b565c52def62696462",
+        "dest": "cargo/vendor/gobject-sys-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e\", \"files\": {}}",
-        "dest": "cargo/vendor/gobject-sys-0.19.8",
+        "contents": "{\"package\": \"a4c674d2ff8478cf0ec29d2be730ed779fef54415a2fb4b565c52def62696462\", \"files\": {}}",
+        "dest": "cargo/vendor/gobject-sys-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.19.8.crate",
-        "sha256": "f5fb86031d24d9ec0a2a15978fc7a65d545a2549642cf1eb7c3dda358da42bcf",
-        "dest": "cargo/vendor/graphene-rs-0.19.8"
+        "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.20.4.crate",
+        "sha256": "1f53144c7fe78292705ff23935f1477d511366fb2f73c43d63b37be89076d2fe",
+        "dest": "cargo/vendor/graphene-rs-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f5fb86031d24d9ec0a2a15978fc7a65d545a2549642cf1eb7c3dda358da42bcf\", \"files\": {}}",
-        "dest": "cargo/vendor/graphene-rs-0.19.8",
+        "contents": "{\"package\": \"1f53144c7fe78292705ff23935f1477d511366fb2f73c43d63b37be89076d2fe\", \"files\": {}}",
+        "dest": "cargo/vendor/graphene-rs-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.19.8.crate",
-        "sha256": "2f530e0944bccba4b55065e9c69f4975ad691609191ebac16e13ab8e1f27af05",
-        "dest": "cargo/vendor/graphene-sys-0.19.8"
+        "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.20.4.crate",
+        "sha256": "e741797dc5081e59877a4d72c442c72d61efdd99161a0b1c1b29b6b988934b99",
+        "dest": "cargo/vendor/graphene-sys-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2f530e0944bccba4b55065e9c69f4975ad691609191ebac16e13ab8e1f27af05\", \"files\": {}}",
-        "dest": "cargo/vendor/graphene-sys-0.19.8",
+        "contents": "{\"package\": \"e741797dc5081e59877a4d72c442c72d61efdd99161a0b1c1b29b6b988934b99\", \"files\": {}}",
+        "dest": "cargo/vendor/graphene-sys-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gsk4/gsk4-0.8.2.crate",
-        "sha256": "7563884bf6939f4468e5d94654945bdd9afcaf8c3ba4c5dd17b5342b747221be",
-        "dest": "cargo/vendor/gsk4-0.8.2"
+        "url": "https://static.crates.io/crates/gsk4/gsk4-0.9.2.crate",
+        "sha256": "aa21a2f7c51ee1c6cc1242c2faf3aae2b7566138f182696759987bde8219e922",
+        "dest": "cargo/vendor/gsk4-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7563884bf6939f4468e5d94654945bdd9afcaf8c3ba4c5dd17b5342b747221be\", \"files\": {}}",
-        "dest": "cargo/vendor/gsk4-0.8.2",
+        "contents": "{\"package\": \"aa21a2f7c51ee1c6cc1242c2faf3aae2b7566138f182696759987bde8219e922\", \"files\": {}}",
+        "dest": "cargo/vendor/gsk4-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.8.2.crate",
-        "sha256": "23024bf2636c38bbd1f822f58acc9d1c25b28da896ff0f291a1a232d4272b3dc",
-        "dest": "cargo/vendor/gsk4-sys-0.8.2"
+        "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.9.2.crate",
+        "sha256": "0f9fb607554f9f4e8829eb7ea301b0fde051e1dbfd5d16b143a8a9c2fac6c01b",
+        "dest": "cargo/vendor/gsk4-sys-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"23024bf2636c38bbd1f822f58acc9d1c25b28da896ff0f291a1a232d4272b3dc\", \"files\": {}}",
-        "dest": "cargo/vendor/gsk4-sys-0.8.2",
+        "contents": "{\"package\": \"0f9fb607554f9f4e8829eb7ea301b0fde051e1dbfd5d16b143a8a9c2fac6c01b\", \"files\": {}}",
+        "dest": "cargo/vendor/gsk4-sys-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4/gtk4-0.8.2.crate",
-        "sha256": "b04e11319b08af11358ab543105a9e49b0c491faca35e2b8e7e36bfba8b671ab",
-        "dest": "cargo/vendor/gtk4-0.8.2"
+        "url": "https://static.crates.io/crates/gtk4/gtk4-0.9.2.crate",
+        "sha256": "31e2d105ce672f5cdcb5af2602e91c2901e91c72da15ab76f613ad57ecf04c6d",
+        "dest": "cargo/vendor/gtk4-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b04e11319b08af11358ab543105a9e49b0c491faca35e2b8e7e36bfba8b671ab\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-0.8.2",
+        "contents": "{\"package\": \"31e2d105ce672f5cdcb5af2602e91c2901e91c72da15ab76f613ad57ecf04c6d\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.8.2.crate",
-        "sha256": "ec655a7ef88d8ce9592899deb8b2d0fa50bab1e6dd69182deb764e643c522408",
-        "dest": "cargo/vendor/gtk4-macros-0.8.2"
+        "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.9.1.crate",
+        "sha256": "e9e7b362c8fccd2712297903717d65d30defdab2b509bc9d209cbe5ffb9fabaf",
+        "dest": "cargo/vendor/gtk4-macros-0.9.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ec655a7ef88d8ce9592899deb8b2d0fa50bab1e6dd69182deb764e643c522408\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-macros-0.8.2",
+        "contents": "{\"package\": \"e9e7b362c8fccd2712297903717d65d30defdab2b509bc9d209cbe5ffb9fabaf\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-macros-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.8.2.crate",
-        "sha256": "8c8aa86b7f85ea71d66ea88c1d4bae1cfacf51ca4856274565133838d77e57b5",
-        "dest": "cargo/vendor/gtk4-sys-0.8.2"
+        "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.9.2.crate",
+        "sha256": "cbe4325908b1c1642dbb48e9f49c07a73185babf43e8b2065b0f881a589f55b8",
+        "dest": "cargo/vendor/gtk4-sys-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8c8aa86b7f85ea71d66ea88c1d4bae1cfacf51ca4856274565133838d77e57b5\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-sys-0.8.2",
+        "contents": "{\"package\": \"cbe4325908b1c1642dbb48e9f49c07a73185babf43e8b2065b0f881a589f55b8\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-sys-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3174,6 +3356,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.13.2.crate",
+        "sha256": "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e",
+        "dest": "cargo/vendor/hashbrown-0.13.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.13.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.5.crate",
         "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
         "dest": "cargo/vendor/hashbrown-0.14.5"
@@ -3182,6 +3377,19 @@
         "type": "inline",
         "contents": "{\"package\": \"e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1\", \"files\": {}}",
         "dest": "cargo/vendor/hashbrown-0.14.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.15.0.crate",
+        "sha256": "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb",
+        "dest": "cargo/vendor/hashbrown-0.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3421,27 +3629,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i18n-embed/i18n-embed-0.14.1.crate",
-        "sha256": "94205d95764f5bb9db9ea98fa77f89653365ca748e27161f5bbea2ffd50e459c",
-        "dest": "cargo/vendor/i18n-embed-0.14.1"
+        "url": "https://static.crates.io/crates/i18n-embed/i18n-embed-0.15.0.crate",
+        "sha256": "e901c87176ac0b615033c81dbe927c230f74700abfd60ed953a6f547c87bbe6d",
+        "dest": "cargo/vendor/i18n-embed-0.15.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"94205d95764f5bb9db9ea98fa77f89653365ca748e27161f5bbea2ffd50e459c\", \"files\": {}}",
-        "dest": "cargo/vendor/i18n-embed-0.14.1",
+        "contents": "{\"package\": \"e901c87176ac0b615033c81dbe927c230f74700abfd60ed953a6f547c87bbe6d\", \"files\": {}}",
+        "dest": "cargo/vendor/i18n-embed-0.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i18n-embed-fl/i18n-embed-fl-0.8.0.crate",
-        "sha256": "8241a781f49e923415e106fcd1f89c3fab92cc9f699a521c56e95dee273903d3",
-        "dest": "cargo/vendor/i18n-embed-fl-0.8.0"
+        "url": "https://static.crates.io/crates/i18n-embed-fl/i18n-embed-fl-0.9.1.crate",
+        "sha256": "d73fe51b9655599147183495551696628b335f75b2dbfa225196b16d69d7288e",
+        "dest": "cargo/vendor/i18n-embed-fl-0.9.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8241a781f49e923415e106fcd1f89c3fab92cc9f699a521c56e95dee273903d3\", \"files\": {}}",
-        "dest": "cargo/vendor/i18n-embed-fl-0.8.0",
+        "contents": "{\"package\": \"d73fe51b9655599147183495551696628b335f75b2dbfa225196b16d69d7288e\", \"files\": {}}",
+        "dest": "cargo/vendor/i18n-embed-fl-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3538,14 +3746,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/image_hasher/image_hasher-1.2.0.crate",
-        "sha256": "8f9e64a8c472ea9f81ac448e3b488fd82dcdfce6434cf880882bf36bfb5c268a",
-        "dest": "cargo/vendor/image_hasher-1.2.0"
+        "url": "https://static.crates.io/crates/image-webp/image-webp-0.1.3.crate",
+        "sha256": "f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904",
+        "dest": "cargo/vendor/image-webp-0.1.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8f9e64a8c472ea9f81ac448e3b488fd82dcdfce6434cf880882bf36bfb5c268a\", \"files\": {}}",
-        "dest": "cargo/vendor/image_hasher-1.2.0",
+        "contents": "{\"package\": \"f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904\", \"files\": {}}",
+        "dest": "cargo/vendor/image-webp-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/image_hasher/image_hasher-2.0.0.crate",
+        "sha256": "9481465fe767d92494987319b0b447a5829edf57f09c52bf8639396abaaeaf78",
+        "dest": "cargo/vendor/image_hasher-2.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9481465fe767d92494987319b0b447a5829edf57f09c52bf8639396abaaeaf78\", \"files\": {}}",
+        "dest": "cargo/vendor/image_hasher-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3603,14 +3824,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/indexmap/indexmap-2.5.0.crate",
-        "sha256": "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5",
-        "dest": "cargo/vendor/indexmap-2.5.0"
+        "url": "https://static.crates.io/crates/indexmap/indexmap-2.6.0.crate",
+        "sha256": "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da",
+        "dest": "cargo/vendor/indexmap-2.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5\", \"files\": {}}",
-        "dest": "cargo/vendor/indexmap-2.5.0",
+        "contents": "{\"package\": \"707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-2.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3629,14 +3850,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/infer/infer-0.15.0.crate",
-        "sha256": "cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199",
-        "dest": "cargo/vendor/infer-0.15.0"
+        "url": "https://static.crates.io/crates/infer/infer-0.16.0.crate",
+        "sha256": "bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847",
+        "dest": "cargo/vendor/infer-0.16.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199\", \"files\": {}}",
-        "dest": "cargo/vendor/infer-0.15.0",
+        "contents": "{\"package\": \"bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847\", \"files\": {}}",
+        "dest": "cargo/vendor/infer-0.16.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3702,6 +3923,19 @@
         "type": "inline",
         "contents": "{\"package\": \"276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770\", \"files\": {}}",
         "dest": "cargo/vendor/integer-sqrt-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/interpolate_name/interpolate_name-0.2.4.crate",
+        "sha256": "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60",
+        "dest": "cargo/vendor/interpolate_name-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60\", \"files\": {}}",
+        "dest": "cargo/vendor/interpolate_name-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3902,14 +4136,157 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.70.crate",
-        "sha256": "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a",
-        "dest": "cargo/vendor/js-sys-0.3.70"
+        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.71.crate",
+        "sha256": "0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b",
+        "dest": "cargo/vendor/js-sys-0.3.71"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a\", \"files\": {}}",
-        "dest": "cargo/vendor/js-sys-0.3.70",
+        "contents": "{\"package\": \"0cb94a0ffd3f3ee755c20f7d8752f45cac88605a4dcf808abcff72873296ec7b\", \"files\": {}}",
+        "dest": "cargo/vendor/js-sys-0.3.71",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-bitstream/jxl-bitstream-0.4.1.crate",
+        "sha256": "5855ff16398ffbcf81fee52c41ca65326499c8764b21bb9952c367ace98995fb",
+        "dest": "cargo/vendor/jxl-bitstream-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5855ff16398ffbcf81fee52c41ca65326499c8764b21bb9952c367ace98995fb\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-bitstream-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-coding/jxl-coding-0.4.1.crate",
+        "sha256": "da5b5093904e940bc11ef50e872c7bdf7b6e88653f012b925f8479daf212b5c9",
+        "dest": "cargo/vendor/jxl-coding-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da5b5093904e940bc11ef50e872c7bdf7b6e88653f012b925f8479daf212b5c9\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-coding-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-color/jxl-color-0.8.0.crate",
+        "sha256": "97f0dd548fabf9c094f9f2304059c86764f606b9040c0bfcfac55f155f423b55",
+        "dest": "cargo/vendor/jxl-color-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"97f0dd548fabf9c094f9f2304059c86764f606b9040c0bfcfac55f155f423b55\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-color-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-frame/jxl-frame-0.10.0.crate",
+        "sha256": "4719f285ebfff5e64f352d0ef149a5244aef4f8e6b5aa666ba6241e90b50632f",
+        "dest": "cargo/vendor/jxl-frame-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4719f285ebfff5e64f352d0ef149a5244aef4f8e6b5aa666ba6241e90b50632f\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-frame-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-grid/jxl-grid-0.5.0.crate",
+        "sha256": "e941628e8de1dc6ba1d2bba8ebc68a69f8ff50cc7ddce5bc821658d1f4ea6e59",
+        "dest": "cargo/vendor/jxl-grid-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e941628e8de1dc6ba1d2bba8ebc68a69f8ff50cc7ddce5bc821658d1f4ea6e59\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-grid-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-image/jxl-image-0.10.0.crate",
+        "sha256": "e3824c81613c05c19a9e4329d569145d3f460c0fcadb3965bd8418162d43f7f4",
+        "dest": "cargo/vendor/jxl-image-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3824c81613c05c19a9e4329d569145d3f460c0fcadb3965bd8418162d43f7f4\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-image-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-modular/jxl-modular-0.8.0.crate",
+        "sha256": "9f48a5d003627f380004c29d35e51672da06ae343a2e6fe8d9c84295b9a3e843",
+        "dest": "cargo/vendor/jxl-modular-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f48a5d003627f380004c29d35e51672da06ae343a2e6fe8d9c84295b9a3e843\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-modular-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-oxide/jxl-oxide-0.9.0.crate",
+        "sha256": "7c209f66ef0fe72df77b44ee6aae98eb87bc2dd236d6981e44e143cc37f33f6e",
+        "dest": "cargo/vendor/jxl-oxide-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c209f66ef0fe72df77b44ee6aae98eb87bc2dd236d6981e44e143cc37f33f6e\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-oxide-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-render/jxl-render-0.9.0.crate",
+        "sha256": "aec53c004c9171e89f15ad1f029d6b638cbd70d3a70276746bb8c75f9393bb64",
+        "dest": "cargo/vendor/jxl-render-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aec53c004c9171e89f15ad1f029d6b638cbd70d3a70276746bb8c75f9393bb64\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-render-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-threadpool/jxl-threadpool-0.1.1.crate",
+        "sha256": "9d2860c68899a3c6266044fc26c6a0041e9f27145f58cc69b6eedc1b77f5ee13",
+        "dest": "cargo/vendor/jxl-threadpool-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d2860c68899a3c6266044fc26c6a0041e9f27145f58cc69b6eedc1b77f5ee13\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-threadpool-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jxl-vardct/jxl-vardct-0.8.0.crate",
+        "sha256": "15da4b49b832b3d8a67329f47e2a1732e0847667938bb9b4a37d99a4668775c2",
+        "dest": "cargo/vendor/jxl-vardct-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"15da4b49b832b3d8a67329f47e2a1732e0847667938bb9b4a37d99a4668775c2\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-vardct-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4027,6 +4404,19 @@
         "type": "inline",
         "contents": "{\"package\": \"e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d\", \"files\": {}}",
         "dest": "cargo/vendor/libflate_lz77-2.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libfuzzer-sys/libfuzzer-sys-0.4.7.crate",
+        "sha256": "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7",
+        "dest": "cargo/vendor/libfuzzer-sys-0.4.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7\", \"files\": {}}",
+        "dest": "cargo/vendor/libfuzzer-sys-0.4.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4240,27 +4630,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lofty/lofty-0.18.2.crate",
-        "sha256": "f75066eb1d25a7047fb2667edb410ae2592439ed81546f95c28b0a1c7d7d3818",
-        "dest": "cargo/vendor/lofty-0.18.2"
+        "url": "https://static.crates.io/crates/lockfree-object-pool/lockfree-object-pool-0.1.6.crate",
+        "sha256": "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e",
+        "dest": "cargo/vendor/lockfree-object-pool-0.1.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f75066eb1d25a7047fb2667edb410ae2592439ed81546f95c28b0a1c7d7d3818\", \"files\": {}}",
-        "dest": "cargo/vendor/lofty-0.18.2",
+        "contents": "{\"package\": \"9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e\", \"files\": {}}",
+        "dest": "cargo/vendor/lockfree-object-pool-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lofty_attr/lofty_attr-0.9.0.crate",
-        "sha256": "764b60e1ddd07e5665a6a17636a95cd7d8f3b86c73503a69c32979d05f72f3cf",
-        "dest": "cargo/vendor/lofty_attr-0.9.0"
+        "url": "https://static.crates.io/crates/lofty/lofty-0.21.1.crate",
+        "sha256": "c8bc4717ff10833a623b009e9254ae8667c7a59edc3cfb01c37aeeef4b6d54a7",
+        "dest": "cargo/vendor/lofty-0.21.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"764b60e1ddd07e5665a6a17636a95cd7d8f3b86c73503a69c32979d05f72f3cf\", \"files\": {}}",
-        "dest": "cargo/vendor/lofty_attr-0.9.0",
+        "contents": "{\"package\": \"c8bc4717ff10833a623b009e9254ae8667c7a59edc3cfb01c37aeeef4b6d54a7\", \"files\": {}}",
+        "dest": "cargo/vendor/lofty-0.21.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lofty_attr/lofty_attr-0.11.0.crate",
+        "sha256": "28bd4b9d8a5af74808932492521cdd272019b056f75fcc70056bd2c09fceb550",
+        "dest": "cargo/vendor/lofty_attr-0.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"28bd4b9d8a5af74808932492521cdd272019b056f75fcc70056bd2c09fceb550\", \"files\": {}}",
+        "dest": "cargo/vendor/lofty_attr-0.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4292,14 +4695,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lru/lru-0.12.4.crate",
-        "sha256": "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904",
-        "dest": "cargo/vendor/lru-0.12.4"
+        "url": "https://static.crates.io/crates/loop9/loop9-0.1.5.crate",
+        "sha256": "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062",
+        "dest": "cargo/vendor/loop9-0.1.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904\", \"files\": {}}",
-        "dest": "cargo/vendor/lru-0.12.4",
+        "contents": "{\"package\": \"0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062\", \"files\": {}}",
+        "dest": "cargo/vendor/loop9-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lru/lru-0.12.5.crate",
+        "sha256": "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38",
+        "dest": "cargo/vendor/lru-0.12.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38\", \"files\": {}}",
+        "dest": "cargo/vendor/lru-0.12.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4378,6 +4794,19 @@
         "type": "inline",
         "contents": "{\"package\": \"8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558\", \"files\": {}}",
         "dest": "cargo/vendor/matchers-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/maybe-rayon/maybe-rayon-0.1.1.crate",
+        "sha256": "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519",
+        "dest": "cargo/vendor/maybe-rayon-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519\", \"files\": {}}",
+        "dest": "cargo/vendor/maybe-rayon-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4513,6 +4942,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mp4parse/mp4parse-0.17.0.crate",
+        "sha256": "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570",
+        "dest": "cargo/vendor/mp4parse-0.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570\", \"files\": {}}",
+        "dest": "cargo/vendor/mp4parse-0.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/multicache/multicache-0.6.1.crate",
         "sha256": "5086074c0a0812980aa88703d1bbcb4433e8423ecf4098a9849934f3dc09ba72",
         "dest": "cargo/vendor/multicache-0.6.1"
@@ -4565,6 +5007,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/new_debug_unreachable/new_debug_unreachable-1.0.6.crate",
+        "sha256": "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086",
+        "dest": "cargo/vendor/new_debug_unreachable-1.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086\", \"files\": {}}",
+        "dest": "cargo/vendor/new_debug_unreachable-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/nix/nix-0.29.0.crate",
         "sha256": "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46",
         "dest": "cargo/vendor/nix-0.29.0"
@@ -4591,6 +5046,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/noop_proc_macro/noop_proc_macro-0.3.0.crate",
+        "sha256": "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8",
+        "dest": "cargo/vendor/noop_proc_macro-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8\", \"files\": {}}",
+        "dest": "cargo/vendor/noop_proc_macro-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/nu-ansi-term/nu-ansi-term-0.46.0.crate",
         "sha256": "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84",
         "dest": "cargo/vendor/nu-ansi-term-0.46.0"
@@ -4599,6 +5067,19 @@
         "type": "inline",
         "contents": "{\"package\": \"77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84\", \"files\": {}}",
         "dest": "cargo/vendor/nu-ansi-term-0.46.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-bigint/num-bigint-0.4.6.crate",
+        "sha256": "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9",
+        "dest": "cargo/vendor/num-bigint-0.4.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9\", \"files\": {}}",
+        "dest": "cargo/vendor/num-bigint-0.4.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4643,6 +5124,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-derive/num-derive-0.4.2.crate",
+        "sha256": "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202",
+        "dest": "cargo/vendor/num-derive-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202\", \"files\": {}}",
+        "dest": "cargo/vendor/num-derive-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.46.crate",
         "sha256": "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f",
         "dest": "cargo/vendor/num-integer-0.1.46"
@@ -4651,6 +5145,19 @@
         "type": "inline",
         "contents": "{\"package\": \"7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f\", \"files\": {}}",
         "dest": "cargo/vendor/num-integer-0.1.46",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-rational/num-rational-0.4.2.crate",
+        "sha256": "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824",
+        "dest": "cargo/vendor/num-rational-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824\", \"files\": {}}",
+        "dest": "cargo/vendor/num-rational-0.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5007,14 +5514,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/once_cell/once_cell-1.20.1.crate",
-        "sha256": "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1",
-        "dest": "cargo/vendor/once_cell-1.20.1"
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.20.2.crate",
+        "sha256": "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775",
+        "dest": "cargo/vendor/once_cell-1.20.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1\", \"files\": {}}",
-        "dest": "cargo/vendor/once_cell-1.20.1",
+        "contents": "{\"package\": \"1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.20.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5085,40 +5592,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.24.0.crate",
-        "sha256": "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90",
-        "dest": "cargo/vendor/owned_ttf_parser-0.24.0"
+        "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.25.0.crate",
+        "sha256": "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4",
+        "dest": "cargo/vendor/owned_ttf_parser-0.25.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90\", \"files\": {}}",
-        "dest": "cargo/vendor/owned_ttf_parser-0.24.0",
+        "contents": "{\"package\": \"22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4\", \"files\": {}}",
+        "dest": "cargo/vendor/owned_ttf_parser-0.25.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pango/pango-0.19.8.crate",
-        "sha256": "3f0d328648058085cfd6897c9ae4272884098a926f3a833cd50c8c73e6eccecd",
-        "dest": "cargo/vendor/pango-0.19.8"
+        "url": "https://static.crates.io/crates/pango/pango-0.20.4.crate",
+        "sha256": "aa26aa54b11094d72141a754901cd71d9356432bb8147f9cace8d9c7ba95f356",
+        "dest": "cargo/vendor/pango-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3f0d328648058085cfd6897c9ae4272884098a926f3a833cd50c8c73e6eccecd\", \"files\": {}}",
-        "dest": "cargo/vendor/pango-0.19.8",
+        "contents": "{\"package\": \"aa26aa54b11094d72141a754901cd71d9356432bb8147f9cace8d9c7ba95f356\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.19.8.crate",
-        "sha256": "ff03da4fa086c0b244d4a4587d3e20622a3ecdb21daea9edf66597224c634ba0",
-        "dest": "cargo/vendor/pango-sys-0.19.8"
+        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.20.4.crate",
+        "sha256": "84fd65917bf12f06544ae2bbc200abf9fc0a513a5a88a0fa81013893aef2b838",
+        "dest": "cargo/vendor/pango-sys-0.20.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ff03da4fa086c0b244d4a4587d3e20622a3ecdb21daea9edf66597224c634ba0\", \"files\": {}}",
-        "dest": "cargo/vendor/pango-sys-0.19.8",
+        "contents": "{\"package\": \"84fd65917bf12f06544ae2bbc200abf9fc0a513a5a88a0fa81013893aef2b838\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-sys-0.20.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5163,19 +5670,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/password-hash/password-hash-0.4.2.crate",
-        "sha256": "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700",
-        "dest": "cargo/vendor/password-hash-0.4.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700\", \"files\": {}}",
-        "dest": "cargo/vendor/password-hash-0.4.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/paste/paste-1.0.15.crate",
         "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
         "dest": "cargo/vendor/paste-1.0.15"
@@ -5202,14 +5696,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pbkdf2/pbkdf2-0.11.0.crate",
-        "sha256": "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917",
-        "dest": "cargo/vendor/pbkdf2-0.11.0"
+        "url": "https://static.crates.io/crates/pbkdf2/pbkdf2-0.12.2.crate",
+        "sha256": "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2",
+        "dest": "cargo/vendor/pbkdf2-0.12.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917\", \"files\": {}}",
-        "dest": "cargo/vendor/pbkdf2-0.11.0",
+        "contents": "{\"package\": \"f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2\", \"files\": {}}",
+        "dest": "cargo/vendor/pbkdf2-0.12.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5267,27 +5761,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pin-project/pin-project-1.1.5.crate",
-        "sha256": "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3",
-        "dest": "cargo/vendor/pin-project-1.1.5"
+        "url": "https://static.crates.io/crates/pin-project/pin-project-1.1.6.crate",
+        "sha256": "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec",
+        "dest": "cargo/vendor/pin-project-1.1.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3\", \"files\": {}}",
-        "dest": "cargo/vendor/pin-project-1.1.5",
+        "contents": "{\"package\": \"baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-1.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.1.5.crate",
-        "sha256": "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965",
-        "dest": "cargo/vendor/pin-project-internal-1.1.5"
+        "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.1.6.crate",
+        "sha256": "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8",
+        "dest": "cargo/vendor/pin-project-internal-1.1.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965\", \"files\": {}}",
-        "dest": "cargo/vendor/pin-project-internal-1.1.5",
+        "contents": "{\"package\": \"a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-internal-1.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5501,14 +5995,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.86.crate",
-        "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
-        "dest": "cargo/vendor/proc-macro2-1.0.86"
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.87.crate",
+        "sha256": "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a",
+        "dest": "cargo/vendor/proc-macro2-1.0.87"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro2-1.0.86",
+        "contents": "{\"package\": \"b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.87",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/profiling/profiling-1.0.15.crate",
+        "sha256": "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58",
+        "dest": "cargo/vendor/profiling-1.0.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58\", \"files\": {}}",
+        "dest": "cargo/vendor/profiling-1.0.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/profiling-procmacros/profiling-procmacros-1.0.15.crate",
+        "sha256": "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd",
+        "dest": "cargo/vendor/profiling-procmacros-1.0.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd\", \"files\": {}}",
+        "dest": "cargo/vendor/profiling-procmacros-1.0.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5522,6 +6042,19 @@
         "type": "inline",
         "contents": "{\"package\": \"7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001\", \"files\": {}}",
         "dest": "cargo/vendor/qoi-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quick-error/quick-error-2.0.1.crate",
+        "sha256": "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3",
+        "dest": "cargo/vendor/quick-error-2.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-error-2.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5587,6 +6120,32 @@
         "type": "inline",
         "contents": "{\"package\": \"ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c\", \"files\": {}}",
         "dest": "cargo/vendor/rand_core-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rav1e/rav1e-0.7.1.crate",
+        "sha256": "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9",
+        "dest": "cargo/vendor/rav1e-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9\", \"files\": {}}",
+        "dest": "cargo/vendor/rav1e-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ravif/ravif-0.11.10.crate",
+        "sha256": "a8f0bfd976333248de2078d350bfdf182ff96e168a24d23d2436cef320dd4bdd",
+        "dest": "cargo/vendor/ravif-0.11.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a8f0bfd976333248de2078d350bfdf182ff96e168a24d23d2436cef320dd4bdd\", \"files\": {}}",
+        "dest": "cargo/vendor/ravif-0.11.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5800,14 +6359,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rfd/rfd-0.14.1.crate",
-        "sha256": "25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251",
-        "dest": "cargo/vendor/rfd-0.14.1"
+        "url": "https://static.crates.io/crates/rfd/rfd-0.15.0.crate",
+        "sha256": "8af382a047821a08aa6bfc09ab0d80ff48d45d8726f7cd8e44891f7cb4a4278e",
+        "dest": "cargo/vendor/rfd-0.15.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251\", \"files\": {}}",
-        "dest": "cargo/vendor/rfd-0.14.1",
+        "contents": "{\"package\": \"8af382a047821a08aa6bfc09ab0d80ff48d45d8726f7cd8e44891f7cb4a4278e\", \"files\": {}}",
+        "dest": "cargo/vendor/rfd-0.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6315,6 +6874,19 @@
         "type": "inline",
         "contents": "{\"package\": \"d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe\", \"files\": {}}",
         "dest": "cargo/vendor/simd-adler32-0.3.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simd_helpers/simd_helpers-0.1.0.crate",
+        "sha256": "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6",
+        "dest": "cargo/vendor/simd_helpers-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6\", \"files\": {}}",
+        "dest": "cargo/vendor/simd_helpers-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6970,6 +7542,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/system-deps/system-deps-7.0.3.crate",
+        "sha256": "66d23aaf9f331227789a99e8de4c91bf46703add012bdfd45fdecdfb2975a005",
+        "dest": "cargo/vendor/system-deps-7.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"66d23aaf9f331227789a99e8de4c91bf46703add012bdfd45fdecdfb2975a005\", \"files\": {}}",
+        "dest": "cargo/vendor/system-deps-7.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tar/tar-0.4.42.crate",
         "sha256": "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020",
         "dest": "cargo/vendor/tar-0.4.42"
@@ -7334,14 +7919,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/trash/trash-3.3.1.crate",
-        "sha256": "c658458d46d9d5a153a3b5cdd88d8579ad50d4fb85d53961e4526c8fc7c55a57",
-        "dest": "cargo/vendor/trash-3.3.1"
+        "url": "https://static.crates.io/crates/trash/trash-5.1.1.crate",
+        "sha256": "33caf2a9be1812a263a4bfce74d2de225fcde12ee7b77001361abd2b34ffdcc4",
+        "dest": "cargo/vendor/trash-5.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c658458d46d9d5a153a3b5cdd88d8579ad50d4fb85d53961e4526c8fc7c55a57\", \"files\": {}}",
-        "dest": "cargo/vendor/trash-3.3.1",
+        "contents": "{\"package\": \"33caf2a9be1812a263a4bfce74d2de225fcde12ee7b77001361abd2b34ffdcc4\", \"files\": {}}",
+        "dest": "cargo/vendor/trash-5.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7373,14 +7958,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.24.1.crate",
-        "sha256": "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a",
-        "dest": "cargo/vendor/ttf-parser-0.24.1"
+        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.25.0.crate",
+        "sha256": "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e",
+        "dest": "cargo/vendor/ttf-parser-0.25.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a\", \"files\": {}}",
-        "dest": "cargo/vendor/ttf-parser-0.24.1",
+        "contents": "{\"package\": \"5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e\", \"files\": {}}",
+        "dest": "cargo/vendor/ttf-parser-0.25.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7503,14 +8088,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.15.crate",
-        "sha256": "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75",
-        "dest": "cargo/vendor/unicode-bidi-0.3.15"
+        "url": "https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.17.crate",
+        "sha256": "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893",
+        "dest": "cargo/vendor/unicode-bidi-0.3.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-bidi-0.3.15",
+        "contents": "{\"package\": \"5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-bidi-0.3.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7711,6 +8296,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/v_frame/v_frame-0.3.8.crate",
+        "sha256": "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b",
+        "dest": "cargo/vendor/v_frame-0.3.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b\", \"files\": {}}",
+        "dest": "cargo/vendor/v_frame-0.3.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/valuable/valuable-0.1.0.crate",
         "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d",
         "dest": "cargo/vendor/valuable-0.1.0"
@@ -7841,79 +8439,79 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.93.crate",
-        "sha256": "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.93"
+        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.94.crate",
+        "sha256": "ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.94"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.93",
+        "contents": "{\"package\": \"ef073ced962d62984fb38a36e5fdc1a2b23c9e0e1fa0689bb97afa4202ef6887\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.94",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.93.crate",
-        "sha256": "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.93"
+        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.94.crate",
+        "sha256": "c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.94"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.93",
+        "contents": "{\"package\": \"c4bfab14ef75323f4eb75fa52ee0a3fb59611977fd3240da19b2cf36ff85030e\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.94",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.43.crate",
-        "sha256": "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed",
-        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.43"
+        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.44.crate",
+        "sha256": "65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.44"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.43",
+        "contents": "{\"package\": \"65471f79c1022ffa5291d33520cbbb53b7687b01c2f8e83b57d102eed7ed479d\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.44",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.93.crate",
-        "sha256": "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.93"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.94.crate",
+        "sha256": "a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.94"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.93",
+        "contents": "{\"package\": \"a7bec9830f60924d9ceb3ef99d55c155be8afa76954edffbb5936ff4509474e7\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.94",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.93.crate",
-        "sha256": "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.93"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.94.crate",
+        "sha256": "4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.94"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.93",
+        "contents": "{\"package\": \"4c74f6e152a76a2ad448e223b0fc0b6b5747649c3d769cc6bf45737bf97d0ed6\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.94",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.93.crate",
-        "sha256": "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.93"
+        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.94.crate",
+        "sha256": "a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.94"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.93",
+        "contents": "{\"package\": \"a42f6c679374623f295a8623adfe63d9284091245c3504bde47c17a3ce2777d9\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.94",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8036,14 +8634,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.70.crate",
-        "sha256": "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0",
-        "dest": "cargo/vendor/web-sys-0.3.70"
+        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.71.crate",
+        "sha256": "44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9",
+        "dest": "cargo/vendor/web-sys-0.3.71"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0\", \"files\": {}}",
-        "dest": "cargo/vendor/web-sys-0.3.70",
+        "contents": "{\"package\": \"44188d185b5bdcae1052d08bcbcf9091a5524038d4572cc4f4f2bb9d5554ddd9\", \"files\": {}}",
+        "dest": "cargo/vendor/web-sys-0.3.71",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8140,19 +8738,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows/windows-0.44.0.crate",
-        "sha256": "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b",
-        "dest": "cargo/vendor/windows-0.44.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b\", \"files\": {}}",
-        "dest": "cargo/vendor/windows-0.44.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows/windows-0.48.0.crate",
         "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
         "dest": "cargo/vendor/windows-0.48.0"
@@ -8161,6 +8746,19 @@
         "type": "inline",
         "contents": "{\"package\": \"e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f\", \"files\": {}}",
         "dest": "cargo/vendor/windows-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows/windows-0.56.0.crate",
+        "sha256": "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132",
+        "dest": "cargo/vendor/windows-0.56.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.56.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8192,6 +8790,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.56.0.crate",
+        "sha256": "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6",
+        "dest": "cargo/vendor/windows-core-0.56.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.56.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows-core/windows-core-0.58.0.crate",
         "sha256": "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99",
         "dest": "cargo/vendor/windows-core-0.58.0"
@@ -8200,6 +8811,19 @@
         "type": "inline",
         "contents": "{\"package\": \"6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99\", \"files\": {}}",
         "dest": "cargo/vendor/windows-core-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-implement/windows-implement-0.56.0.crate",
+        "sha256": "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b",
+        "dest": "cargo/vendor/windows-implement-0.56.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-implement-0.56.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8218,6 +8842,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-interface/windows-interface-0.56.0.crate",
+        "sha256": "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc",
+        "dest": "cargo/vendor/windows-interface-0.56.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-interface-0.56.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows-interface/windows-interface-0.58.0.crate",
         "sha256": "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515",
         "dest": "cargo/vendor/windows-interface-0.58.0"
@@ -8226,6 +8863,19 @@
         "type": "inline",
         "contents": "{\"package\": \"053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515\", \"files\": {}}",
         "dest": "cargo/vendor/windows-interface-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-result/windows-result-0.1.2.crate",
+        "sha256": "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8",
+        "dest": "cargo/vendor/windows-result-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-result-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8920,14 +9570,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zip/zip-0.6.6.crate",
-        "sha256": "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261",
-        "dest": "cargo/vendor/zip-0.6.6"
+        "url": "https://static.crates.io/crates/zeroize/zeroize-1.8.1.crate",
+        "sha256": "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde",
+        "dest": "cargo/vendor/zeroize-1.8.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261\", \"files\": {}}",
-        "dest": "cargo/vendor/zip-0.6.6",
+        "contents": "{\"package\": \"ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde\", \"files\": {}}",
+        "dest": "cargo/vendor/zeroize-1.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zeroize_derive/zeroize_derive-1.4.2.crate",
+        "sha256": "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69",
+        "dest": "cargo/vendor/zeroize_derive-1.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69\", \"files\": {}}",
+        "dest": "cargo/vendor/zeroize_derive-1.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zip/zip-2.2.0.crate",
+        "sha256": "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494",
+        "dest": "cargo/vendor/zip-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494\", \"files\": {}}",
+        "dest": "cargo/vendor/zip-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zopfli/zopfli-0.8.1.crate",
+        "sha256": "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946",
+        "dest": "cargo/vendor/zopfli-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946\", \"files\": {}}",
+        "dest": "cargo/vendor/zopfli-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zune-core/zune-core-0.4.12.crate",
+        "sha256": "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a",
+        "dest": "cargo/vendor/zune-core-0.4.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-core-0.4.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8941,6 +9643,19 @@
         "type": "inline",
         "contents": "{\"package\": \"73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02\", \"files\": {}}",
         "dest": "cargo/vendor/zune-inflate-0.2.54",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zune-jpeg/zune-jpeg-0.4.13.crate",
+        "sha256": "16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768",
+        "dest": "cargo/vendor/zune-jpeg-0.4.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-jpeg-0.4.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -2,14 +2,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.23.crate",
-        "sha256": "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225",
-        "dest": "cargo/vendor/ab_glyph-0.2.23"
+        "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.28.crate",
+        "sha256": "79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb",
+        "dest": "cargo/vendor/ab_glyph-0.2.28"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225\", \"files\": {}}",
-        "dest": "cargo/vendor/ab_glyph-0.2.23",
+        "contents": "{\"package\": \"79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb\", \"files\": {}}",
+        "dest": "cargo/vendor/ab_glyph-0.2.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -41,6 +41,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/adler2/adler2-2.0.0.crate",
+        "sha256": "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627",
+        "dest": "cargo/vendor/adler2-2.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627\", \"files\": {}}",
+        "dest": "cargo/vendor/adler2-2.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/adler32/adler32-1.2.0.crate",
         "sha256": "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234",
         "dest": "cargo/vendor/adler32-1.2.0"
@@ -67,53 +80,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ahash/ahash-0.8.8.crate",
-        "sha256": "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff",
-        "dest": "cargo/vendor/ahash-0.8.8"
+        "url": "https://static.crates.io/crates/ahash/ahash-0.8.11.crate",
+        "sha256": "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011",
+        "dest": "cargo/vendor/ahash-0.8.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff\", \"files\": {}}",
-        "dest": "cargo/vendor/ahash-0.8.8",
+        "contents": "{\"package\": \"e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011\", \"files\": {}}",
+        "dest": "cargo/vendor/ahash-0.8.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.2.crate",
-        "sha256": "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0",
-        "dest": "cargo/vendor/aho-corasick-1.1.2"
+        "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.3.crate",
+        "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+        "dest": "cargo/vendor/aho-corasick-1.1.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0\", \"files\": {}}",
-        "dest": "cargo/vendor/aho-corasick-1.1.2",
+        "contents": "{\"package\": \"8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916\", \"files\": {}}",
+        "dest": "cargo/vendor/aho-corasick-1.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/allocator-api2/allocator-api2-0.2.16.crate",
-        "sha256": "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5",
-        "dest": "cargo/vendor/allocator-api2-0.2.16"
+        "url": "https://static.crates.io/crates/allocator-api2/allocator-api2-0.2.18.crate",
+        "sha256": "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f",
+        "dest": "cargo/vendor/allocator-api2-0.2.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5\", \"files\": {}}",
-        "dest": "cargo/vendor/allocator-api2-0.2.16",
+        "contents": "{\"package\": \"5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f\", \"files\": {}}",
+        "dest": "cargo/vendor/allocator-api2-0.2.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/android-activity/android-activity-0.5.2.crate",
-        "sha256": "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289",
-        "dest": "cargo/vendor/android-activity-0.5.2"
+        "url": "https://static.crates.io/crates/android-activity/android-activity-0.6.0.crate",
+        "sha256": "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046",
+        "dest": "cargo/vendor/android-activity-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289\", \"files\": {}}",
-        "dest": "cargo/vendor/android-activity-0.5.2",
+        "contents": "{\"package\": \"ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046\", \"files\": {}}",
+        "dest": "cargo/vendor/android-activity-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -158,118 +171,118 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstream/anstream-0.6.12.crate",
-        "sha256": "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540",
-        "dest": "cargo/vendor/anstream-0.6.12"
+        "url": "https://static.crates.io/crates/anstream/anstream-0.6.15.crate",
+        "sha256": "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526",
+        "dest": "cargo/vendor/anstream-0.6.15"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540\", \"files\": {}}",
-        "dest": "cargo/vendor/anstream-0.6.12",
+        "contents": "{\"package\": \"64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526\", \"files\": {}}",
+        "dest": "cargo/vendor/anstream-0.6.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstyle/anstyle-1.0.6.crate",
-        "sha256": "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc",
-        "dest": "cargo/vendor/anstyle-1.0.6"
+        "url": "https://static.crates.io/crates/anstyle/anstyle-1.0.8.crate",
+        "sha256": "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1",
+        "dest": "cargo/vendor/anstyle-1.0.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc\", \"files\": {}}",
-        "dest": "cargo/vendor/anstyle-1.0.6",
+        "contents": "{\"package\": \"1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-1.0.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstyle-parse/anstyle-parse-0.2.3.crate",
-        "sha256": "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c",
-        "dest": "cargo/vendor/anstyle-parse-0.2.3"
+        "url": "https://static.crates.io/crates/anstyle-parse/anstyle-parse-0.2.5.crate",
+        "sha256": "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb",
+        "dest": "cargo/vendor/anstyle-parse-0.2.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c\", \"files\": {}}",
-        "dest": "cargo/vendor/anstyle-parse-0.2.3",
+        "contents": "{\"package\": \"eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-parse-0.2.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstyle-query/anstyle-query-1.0.2.crate",
-        "sha256": "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648",
-        "dest": "cargo/vendor/anstyle-query-1.0.2"
+        "url": "https://static.crates.io/crates/anstyle-query/anstyle-query-1.1.1.crate",
+        "sha256": "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a",
+        "dest": "cargo/vendor/anstyle-query-1.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648\", \"files\": {}}",
-        "dest": "cargo/vendor/anstyle-query-1.0.2",
+        "contents": "{\"package\": \"6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-query-1.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstyle-wincon/anstyle-wincon-3.0.2.crate",
-        "sha256": "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7",
-        "dest": "cargo/vendor/anstyle-wincon-3.0.2"
+        "url": "https://static.crates.io/crates/anstyle-wincon/anstyle-wincon-3.0.4.crate",
+        "sha256": "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8",
+        "dest": "cargo/vendor/anstyle-wincon-3.0.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7\", \"files\": {}}",
-        "dest": "cargo/vendor/anstyle-wincon-3.0.2",
+        "contents": "{\"package\": \"5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-wincon-3.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.79.crate",
-        "sha256": "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca",
-        "dest": "cargo/vendor/anyhow-1.0.79"
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.89.crate",
+        "sha256": "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6",
+        "dest": "cargo/vendor/anyhow-1.0.89"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca\", \"files\": {}}",
-        "dest": "cargo/vendor/anyhow-1.0.79",
+        "contents": "{\"package\": \"86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6\", \"files\": {}}",
+        "dest": "cargo/vendor/anyhow-1.0.89",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/arc-swap/arc-swap-1.6.0.crate",
-        "sha256": "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6",
-        "dest": "cargo/vendor/arc-swap-1.6.0"
+        "url": "https://static.crates.io/crates/arc-swap/arc-swap-1.7.1.crate",
+        "sha256": "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457",
+        "dest": "cargo/vendor/arc-swap-1.7.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6\", \"files\": {}}",
-        "dest": "cargo/vendor/arc-swap-1.6.0",
+        "contents": "{\"package\": \"69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457\", \"files\": {}}",
+        "dest": "cargo/vendor/arc-swap-1.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/arrayref/arrayref-0.3.7.crate",
-        "sha256": "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545",
-        "dest": "cargo/vendor/arrayref-0.3.7"
+        "url": "https://static.crates.io/crates/arrayref/arrayref-0.3.9.crate",
+        "sha256": "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb",
+        "dest": "cargo/vendor/arrayref-0.3.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545\", \"files\": {}}",
-        "dest": "cargo/vendor/arrayref-0.3.7",
+        "contents": "{\"package\": \"76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayref-0.3.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.4.crate",
-        "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711",
-        "dest": "cargo/vendor/arrayvec-0.7.4"
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.6.crate",
+        "sha256": "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50",
+        "dest": "cargo/vendor/arrayvec-0.7.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711\", \"files\": {}}",
-        "dest": "cargo/vendor/arrayvec-0.7.4",
+        "contents": "{\"package\": \"7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayvec-0.7.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -301,131 +314,92 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ashpd/ashpd-0.6.8.crate",
-        "sha256": "4ac22eda5891cc086690cb6fa10121c0390de0e3b04eb269f2d766b00d3f2d81",
-        "dest": "cargo/vendor/ashpd-0.6.8"
+        "url": "https://static.crates.io/crates/ashpd/ashpd-0.8.1.crate",
+        "sha256": "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093",
+        "dest": "cargo/vendor/ashpd-0.8.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4ac22eda5891cc086690cb6fa10121c0390de0e3b04eb269f2d766b00d3f2d81\", \"files\": {}}",
-        "dest": "cargo/vendor/ashpd-0.6.8",
+        "contents": "{\"package\": \"dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093\", \"files\": {}}",
+        "dest": "cargo/vendor/ashpd-0.8.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-broadcast/async-broadcast-0.5.1.crate",
-        "sha256": "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b",
-        "dest": "cargo/vendor/async-broadcast-0.5.1"
+        "url": "https://static.crates.io/crates/async-broadcast/async-broadcast-0.7.1.crate",
+        "sha256": "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e",
+        "dest": "cargo/vendor/async-broadcast-0.7.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b\", \"files\": {}}",
-        "dest": "cargo/vendor/async-broadcast-0.5.1",
+        "contents": "{\"package\": \"20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e\", \"files\": {}}",
+        "dest": "cargo/vendor/async-broadcast-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-channel/async-channel-2.2.0.crate",
-        "sha256": "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3",
-        "dest": "cargo/vendor/async-channel-2.2.0"
+        "url": "https://static.crates.io/crates/async-channel/async-channel-2.3.1.crate",
+        "sha256": "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a",
+        "dest": "cargo/vendor/async-channel-2.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3\", \"files\": {}}",
-        "dest": "cargo/vendor/async-channel-2.2.0",
+        "contents": "{\"package\": \"89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a\", \"files\": {}}",
+        "dest": "cargo/vendor/async-channel-2.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-executor/async-executor-1.8.0.crate",
-        "sha256": "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c",
-        "dest": "cargo/vendor/async-executor-1.8.0"
+        "url": "https://static.crates.io/crates/async-executor/async-executor-1.13.1.crate",
+        "sha256": "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec",
+        "dest": "cargo/vendor/async-executor-1.13.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c\", \"files\": {}}",
-        "dest": "cargo/vendor/async-executor-1.8.0",
+        "contents": "{\"package\": \"30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec\", \"files\": {}}",
+        "dest": "cargo/vendor/async-executor-1.13.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-fs/async-fs-1.6.0.crate",
-        "sha256": "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06",
-        "dest": "cargo/vendor/async-fs-1.6.0"
+        "url": "https://static.crates.io/crates/async-fs/async-fs-2.1.2.crate",
+        "sha256": "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a",
+        "dest": "cargo/vendor/async-fs-2.1.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06\", \"files\": {}}",
-        "dest": "cargo/vendor/async-fs-1.6.0",
+        "contents": "{\"package\": \"ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a\", \"files\": {}}",
+        "dest": "cargo/vendor/async-fs-2.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-fs/async-fs-2.1.1.crate",
-        "sha256": "bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1",
-        "dest": "cargo/vendor/async-fs-2.1.1"
+        "url": "https://static.crates.io/crates/async-io/async-io-2.3.4.crate",
+        "sha256": "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8",
+        "dest": "cargo/vendor/async-io-2.3.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1\", \"files\": {}}",
-        "dest": "cargo/vendor/async-fs-2.1.1",
+        "contents": "{\"package\": \"444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8\", \"files\": {}}",
+        "dest": "cargo/vendor/async-io-2.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-io/async-io-1.13.0.crate",
-        "sha256": "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af",
-        "dest": "cargo/vendor/async-io-1.13.0"
+        "url": "https://static.crates.io/crates/async-lock/async-lock-3.4.0.crate",
+        "sha256": "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18",
+        "dest": "cargo/vendor/async-lock-3.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af\", \"files\": {}}",
-        "dest": "cargo/vendor/async-io-1.13.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-io/async-io-2.3.1.crate",
-        "sha256": "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65",
-        "dest": "cargo/vendor/async-io-2.3.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65\", \"files\": {}}",
-        "dest": "cargo/vendor/async-io-2.3.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-lock/async-lock-2.8.0.crate",
-        "sha256": "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b",
-        "dest": "cargo/vendor/async-lock-2.8.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b\", \"files\": {}}",
-        "dest": "cargo/vendor/async-lock-2.8.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-lock/async-lock-3.3.0.crate",
-        "sha256": "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b",
-        "dest": "cargo/vendor/async-lock-3.3.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b\", \"files\": {}}",
-        "dest": "cargo/vendor/async-lock-3.3.0",
+        "contents": "{\"package\": \"ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18\", \"files\": {}}",
+        "dest": "cargo/vendor/async-lock-3.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -444,66 +418,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-process/async-process-1.8.1.crate",
-        "sha256": "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88",
-        "dest": "cargo/vendor/async-process-1.8.1"
+        "url": "https://static.crates.io/crates/async-process/async-process-2.3.0.crate",
+        "sha256": "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb",
+        "dest": "cargo/vendor/async-process-2.3.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88\", \"files\": {}}",
-        "dest": "cargo/vendor/async-process-1.8.1",
+        "contents": "{\"package\": \"63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb\", \"files\": {}}",
+        "dest": "cargo/vendor/async-process-2.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-recursion/async-recursion-1.0.5.crate",
-        "sha256": "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0",
-        "dest": "cargo/vendor/async-recursion-1.0.5"
+        "url": "https://static.crates.io/crates/async-recursion/async-recursion-1.1.1.crate",
+        "sha256": "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11",
+        "dest": "cargo/vendor/async-recursion-1.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0\", \"files\": {}}",
-        "dest": "cargo/vendor/async-recursion-1.0.5",
+        "contents": "{\"package\": \"3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11\", \"files\": {}}",
+        "dest": "cargo/vendor/async-recursion-1.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-signal/async-signal-0.2.5.crate",
-        "sha256": "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5",
-        "dest": "cargo/vendor/async-signal-0.2.5"
+        "url": "https://static.crates.io/crates/async-signal/async-signal-0.2.10.crate",
+        "sha256": "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3",
+        "dest": "cargo/vendor/async-signal-0.2.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5\", \"files\": {}}",
-        "dest": "cargo/vendor/async-signal-0.2.5",
+        "contents": "{\"package\": \"637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3\", \"files\": {}}",
+        "dest": "cargo/vendor/async-signal-0.2.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-task/async-task-4.7.0.crate",
-        "sha256": "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799",
-        "dest": "cargo/vendor/async-task-4.7.0"
+        "url": "https://static.crates.io/crates/async-task/async-task-4.7.1.crate",
+        "sha256": "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de",
+        "dest": "cargo/vendor/async-task-4.7.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799\", \"files\": {}}",
-        "dest": "cargo/vendor/async-task-4.7.0",
+        "contents": "{\"package\": \"8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de\", \"files\": {}}",
+        "dest": "cargo/vendor/async-task-4.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.77.crate",
-        "sha256": "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9",
-        "dest": "cargo/vendor/async-trait-0.1.77"
+        "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.83.crate",
+        "sha256": "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd",
+        "dest": "cargo/vendor/async-trait-0.1.83"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9\", \"files\": {}}",
-        "dest": "cargo/vendor/async-trait-0.1.77",
+        "contents": "{\"package\": \"721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd\", \"files\": {}}",
+        "dest": "cargo/vendor/async-trait-0.1.83",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -535,27 +509,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/auto_enums/auto_enums-0.8.5.crate",
-        "sha256": "1899bfcfd9340ceea3533ea157360ba8fa864354eccbceab58e1006ecab35393",
-        "dest": "cargo/vendor/auto_enums-0.8.5"
+        "url": "https://static.crates.io/crates/auto_enums/auto_enums-0.8.6.crate",
+        "sha256": "459b77b7e855f875fd15f101064825cd79eb83185a961d66e6298560126facfb",
+        "dest": "cargo/vendor/auto_enums-0.8.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1899bfcfd9340ceea3533ea157360ba8fa864354eccbceab58e1006ecab35393\", \"files\": {}}",
-        "dest": "cargo/vendor/auto_enums-0.8.5",
+        "contents": "{\"package\": \"459b77b7e855f875fd15f101064825cd79eb83185a961d66e6298560126facfb\", \"files\": {}}",
+        "dest": "cargo/vendor/auto_enums-0.8.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/autocfg/autocfg-1.1.0.crate",
-        "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
-        "dest": "cargo/vendor/autocfg-1.1.0"
+        "url": "https://static.crates.io/crates/autocfg/autocfg-1.4.0.crate",
+        "sha256": "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26",
+        "dest": "cargo/vendor/autocfg-1.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa\", \"files\": {}}",
-        "dest": "cargo/vendor/autocfg-1.1.0",
+        "contents": "{\"package\": \"ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26\", \"files\": {}}",
+        "dest": "cargo/vendor/autocfg-1.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -574,6 +548,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.22.1.crate",
+        "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+        "dest": "cargo/vendor/base64-0.22.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.22.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/base64ct/base64ct-1.6.0.crate",
         "sha256": "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b",
         "dest": "cargo/vendor/base64ct-1.6.0"
@@ -582,6 +569,19 @@
         "type": "inline",
         "contents": "{\"package\": \"8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b\", \"files\": {}}",
         "dest": "cargo/vendor/base64ct-1.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/basic-toml/basic-toml-0.1.9.crate",
+        "sha256": "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8",
+        "dest": "cargo/vendor/basic-toml-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8\", \"files\": {}}",
+        "dest": "cargo/vendor/basic-toml-0.1.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -639,14 +639,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bitflags/bitflags-2.4.2.crate",
-        "sha256": "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf",
-        "dest": "cargo/vendor/bitflags-2.4.2"
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.6.0.crate",
+        "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+        "dest": "cargo/vendor/bitflags-2.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf\", \"files\": {}}",
-        "dest": "cargo/vendor/bitflags-2.4.2",
+        "contents": "{\"package\": \"b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-2.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -665,14 +665,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/blake3/blake3-1.5.0.crate",
-        "sha256": "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87",
-        "dest": "cargo/vendor/blake3-1.5.0"
+        "url": "https://static.crates.io/crates/blake3/blake3-1.5.4.crate",
+        "sha256": "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7",
+        "dest": "cargo/vendor/blake3-1.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87\", \"files\": {}}",
-        "dest": "cargo/vendor/blake3-1.5.0",
+        "contents": "{\"package\": \"d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7\", \"files\": {}}",
+        "dest": "cargo/vendor/blake3-1.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -717,92 +717,92 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/block-sys/block-sys-0.2.1.crate",
-        "sha256": "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7",
-        "dest": "cargo/vendor/block-sys-0.2.1"
+        "url": "https://static.crates.io/crates/block2/block2-0.5.1.crate",
+        "sha256": "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f",
+        "dest": "cargo/vendor/block2-0.5.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7\", \"files\": {}}",
-        "dest": "cargo/vendor/block-sys-0.2.1",
+        "contents": "{\"package\": \"2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f\", \"files\": {}}",
+        "dest": "cargo/vendor/block2-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/block2/block2-0.3.0.crate",
-        "sha256": "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68",
-        "dest": "cargo/vendor/block2-0.3.0"
+        "url": "https://static.crates.io/crates/blocking/blocking-1.6.1.crate",
+        "sha256": "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea",
+        "dest": "cargo/vendor/blocking-1.6.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68\", \"files\": {}}",
-        "dest": "cargo/vendor/block2-0.3.0",
+        "contents": "{\"package\": \"703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea\", \"files\": {}}",
+        "dest": "cargo/vendor/blocking-1.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/blocking/blocking-1.5.1.crate",
-        "sha256": "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118",
-        "dest": "cargo/vendor/blocking-1.5.1"
+        "url": "https://static.crates.io/crates/borsh/borsh-1.5.1.crate",
+        "sha256": "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed",
+        "dest": "cargo/vendor/borsh-1.5.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118\", \"files\": {}}",
-        "dest": "cargo/vendor/blocking-1.5.1",
+        "contents": "{\"package\": \"a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed\", \"files\": {}}",
+        "dest": "cargo/vendor/borsh-1.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.15.0.crate",
-        "sha256": "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f",
-        "dest": "cargo/vendor/bumpalo-3.15.0"
+        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.16.0.crate",
+        "sha256": "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c",
+        "dest": "cargo/vendor/bumpalo-3.16.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f\", \"files\": {}}",
-        "dest": "cargo/vendor/bumpalo-3.15.0",
+        "contents": "{\"package\": \"79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c\", \"files\": {}}",
+        "dest": "cargo/vendor/bumpalo-3.16.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/by_address/by_address-1.1.0.crate",
-        "sha256": "bf8dba2868114ed769a1f2590fc9ae5eb331175b44313b6c9b922f8f7ca813d0",
-        "dest": "cargo/vendor/by_address-1.1.0"
+        "url": "https://static.crates.io/crates/by_address/by_address-1.2.1.crate",
+        "sha256": "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06",
+        "dest": "cargo/vendor/by_address-1.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bf8dba2868114ed769a1f2590fc9ae5eb331175b44313b6c9b922f8f7ca813d0\", \"files\": {}}",
-        "dest": "cargo/vendor/by_address-1.1.0",
+        "contents": "{\"package\": \"64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06\", \"files\": {}}",
+        "dest": "cargo/vendor/by_address-1.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.14.3.crate",
-        "sha256": "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f",
-        "dest": "cargo/vendor/bytemuck-1.14.3"
+        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.18.0.crate",
+        "sha256": "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae",
+        "dest": "cargo/vendor/bytemuck-1.18.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f\", \"files\": {}}",
-        "dest": "cargo/vendor/bytemuck-1.14.3",
+        "contents": "{\"package\": \"94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck-1.18.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bytemuck_derive/bytemuck_derive-1.5.0.crate",
-        "sha256": "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1",
-        "dest": "cargo/vendor/bytemuck_derive-1.5.0"
+        "url": "https://static.crates.io/crates/bytemuck_derive/bytemuck_derive-1.7.1.crate",
+        "sha256": "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26",
+        "dest": "cargo/vendor/bytemuck_derive-1.7.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1\", \"files\": {}}",
-        "dest": "cargo/vendor/bytemuck_derive-1.5.0",
+        "contents": "{\"package\": \"0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck_derive-1.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -821,14 +821,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bytes/bytes-1.5.0.crate",
-        "sha256": "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223",
-        "dest": "cargo/vendor/bytes-1.5.0"
+        "url": "https://static.crates.io/crates/byteorder-lite/byteorder-lite-0.1.0.crate",
+        "sha256": "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495",
+        "dest": "cargo/vendor/byteorder-lite-0.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223\", \"files\": {}}",
-        "dest": "cargo/vendor/bytes-1.5.0",
+        "contents": "{\"package\": \"8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495\", \"files\": {}}",
+        "dest": "cargo/vendor/byteorder-lite-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytes/bytes-1.7.2.crate",
+        "sha256": "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3",
+        "dest": "cargo/vendor/bytes-1.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3\", \"files\": {}}",
+        "dest": "cargo/vendor/bytes-1.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -860,14 +873,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.19.2.crate",
-        "sha256": "2650f66005301bd33cc486dec076e1293c4cecf768bc7ba9bf5d2b1be339b99c",
-        "dest": "cargo/vendor/cairo-rs-0.19.2"
+        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.19.4.crate",
+        "sha256": "b2ac2a4d0e69036cf0062976f6efcba1aaee3e448594e6514bb2ddf87acce562",
+        "dest": "cargo/vendor/cairo-rs-0.19.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2650f66005301bd33cc486dec076e1293c4cecf768bc7ba9bf5d2b1be339b99c\", \"files\": {}}",
-        "dest": "cargo/vendor/cairo-rs-0.19.2",
+        "contents": "{\"package\": \"b2ac2a4d0e69036cf0062976f6efcba1aaee3e448594e6514bb2ddf87acce562\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-rs-0.19.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -886,27 +899,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/calloop/calloop-0.12.4.crate",
-        "sha256": "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298",
-        "dest": "cargo/vendor/calloop-0.12.4"
+        "url": "https://static.crates.io/crates/calloop/calloop-0.13.0.crate",
+        "sha256": "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec",
+        "dest": "cargo/vendor/calloop-0.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298\", \"files\": {}}",
-        "dest": "cargo/vendor/calloop-0.12.4",
+        "contents": "{\"package\": \"b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec\", \"files\": {}}",
+        "dest": "cargo/vendor/calloop-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/calloop-wayland-source/calloop-wayland-source-0.2.0.crate",
-        "sha256": "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02",
-        "dest": "cargo/vendor/calloop-wayland-source-0.2.0"
+        "url": "https://static.crates.io/crates/calloop/calloop-0.14.1.crate",
+        "sha256": "a1ead1e1514bce44c0f40e027899fbc595907fc112635bed21b3b5d975c0a5e7",
+        "dest": "cargo/vendor/calloop-0.14.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02\", \"files\": {}}",
-        "dest": "cargo/vendor/calloop-wayland-source-0.2.0",
+        "contents": "{\"package\": \"a1ead1e1514bce44c0f40e027899fbc595907fc112635bed21b3b5d975c0a5e7\", \"files\": {}}",
+        "dest": "cargo/vendor/calloop-0.14.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/calloop-wayland-source/calloop-wayland-source-0.3.0.crate",
+        "sha256": "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20",
+        "dest": "cargo/vendor/calloop-wayland-source-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20\", \"files\": {}}",
+        "dest": "cargo/vendor/calloop-wayland-source-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -925,14 +951,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.0.83.crate",
-        "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
-        "dest": "cargo/vendor/cc-1.0.83"
+        "url": "https://static.crates.io/crates/cc/cc-1.1.23.crate",
+        "sha256": "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17",
+        "dest": "cargo/vendor/cc-1.1.23"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.0.83",
+        "contents": "{\"package\": \"3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.1.23",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -977,14 +1003,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.15.7.crate",
-        "sha256": "fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d",
-        "dest": "cargo/vendor/cfg-expr-0.15.7"
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.15.8.crate",
+        "sha256": "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02",
+        "dest": "cargo/vendor/cfg-expr-0.15.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d\", \"files\": {}}",
-        "dest": "cargo/vendor/cfg-expr-0.15.7",
+        "contents": "{\"package\": \"d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-expr-0.15.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1003,27 +1029,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.1.1.crate",
-        "sha256": "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e",
-        "dest": "cargo/vendor/cfg_aliases-0.1.1"
+        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.2.1.crate",
+        "sha256": "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724",
+        "dest": "cargo/vendor/cfg_aliases-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e\", \"files\": {}}",
-        "dest": "cargo/vendor/cfg_aliases-0.1.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.2.0.crate",
-        "sha256": "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f",
-        "dest": "cargo/vendor/cfg_aliases-0.2.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f\", \"files\": {}}",
-        "dest": "cargo/vendor/cfg_aliases-0.2.0",
+        "contents": "{\"package\": \"613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg_aliases-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1042,14 +1055,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/chrono/chrono-0.4.34.crate",
-        "sha256": "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b",
-        "dest": "cargo/vendor/chrono-0.4.34"
+        "url": "https://static.crates.io/crates/chrono/chrono-0.4.38.crate",
+        "sha256": "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401",
+        "dest": "cargo/vendor/chrono-0.4.38"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b\", \"files\": {}}",
-        "dest": "cargo/vendor/chrono-0.4.34",
+        "contents": "{\"package\": \"a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401\", \"files\": {}}",
+        "dest": "cargo/vendor/chrono-0.4.38",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1068,66 +1081,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clang-sys/clang-sys-1.7.0.crate",
-        "sha256": "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1",
-        "dest": "cargo/vendor/clang-sys-1.7.0"
+        "url": "https://static.crates.io/crates/clang-sys/clang-sys-1.8.1.crate",
+        "sha256": "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4",
+        "dest": "cargo/vendor/clang-sys-1.8.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1\", \"files\": {}}",
-        "dest": "cargo/vendor/clang-sys-1.7.0",
+        "contents": "{\"package\": \"0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4\", \"files\": {}}",
+        "dest": "cargo/vendor/clang-sys-1.8.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap/clap-4.5.1.crate",
-        "sha256": "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da",
-        "dest": "cargo/vendor/clap-4.5.1"
+        "url": "https://static.crates.io/crates/clap/clap-4.5.18.crate",
+        "sha256": "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3",
+        "dest": "cargo/vendor/clap-4.5.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da\", \"files\": {}}",
-        "dest": "cargo/vendor/clap-4.5.1",
+        "contents": "{\"package\": \"b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3\", \"files\": {}}",
+        "dest": "cargo/vendor/clap-4.5.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap_builder/clap_builder-4.5.1.crate",
-        "sha256": "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb",
-        "dest": "cargo/vendor/clap_builder-4.5.1"
+        "url": "https://static.crates.io/crates/clap_builder/clap_builder-4.5.18.crate",
+        "sha256": "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b",
+        "dest": "cargo/vendor/clap_builder-4.5.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb\", \"files\": {}}",
-        "dest": "cargo/vendor/clap_builder-4.5.1",
+        "contents": "{\"package\": \"4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_builder-4.5.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap_derive/clap_derive-4.5.0.crate",
-        "sha256": "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47",
-        "dest": "cargo/vendor/clap_derive-4.5.0"
+        "url": "https://static.crates.io/crates/clap_derive/clap_derive-4.5.18.crate",
+        "sha256": "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab",
+        "dest": "cargo/vendor/clap_derive-4.5.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47\", \"files\": {}}",
-        "dest": "cargo/vendor/clap_derive-4.5.0",
+        "contents": "{\"package\": \"4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_derive-4.5.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap_lex/clap_lex-0.7.0.crate",
-        "sha256": "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce",
-        "dest": "cargo/vendor/clap_lex-0.7.0"
+        "url": "https://static.crates.io/crates/clap_lex/clap_lex-0.7.2.crate",
+        "sha256": "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97",
+        "dest": "cargo/vendor/clap_lex-0.7.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce\", \"files\": {}}",
-        "dest": "cargo/vendor/clap_lex-0.7.0",
+        "contents": "{\"package\": \"1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_lex-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1146,14 +1159,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clru/clru-0.6.1.crate",
-        "sha256": "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807",
-        "dest": "cargo/vendor/clru-0.6.1"
+        "url": "https://static.crates.io/crates/clru/clru-0.6.2.crate",
+        "sha256": "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59",
+        "dest": "cargo/vendor/clru-0.6.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807\", \"files\": {}}",
-        "dest": "cargo/vendor/clru-0.6.1",
+        "contents": "{\"package\": \"cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59\", \"files\": {}}",
+        "dest": "cargo/vendor/clru-0.6.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1224,40 +1237,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/colorchoice/colorchoice-1.0.0.crate",
-        "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
-        "dest": "cargo/vendor/colorchoice-1.0.0"
+        "url": "https://static.crates.io/crates/colorchoice/colorchoice-1.0.2.crate",
+        "sha256": "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0",
+        "dest": "cargo/vendor/colorchoice-1.0.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7\", \"files\": {}}",
-        "dest": "cargo/vendor/colorchoice-1.0.0",
+        "contents": "{\"package\": \"d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0\", \"files\": {}}",
+        "dest": "cargo/vendor/colorchoice-1.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/combine/combine-4.6.6.crate",
-        "sha256": "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4",
-        "dest": "cargo/vendor/combine-4.6.6"
+        "url": "https://static.crates.io/crates/combine/combine-4.6.7.crate",
+        "sha256": "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd",
+        "dest": "cargo/vendor/combine-4.6.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4\", \"files\": {}}",
-        "dest": "cargo/vendor/combine-4.6.6",
+        "contents": "{\"package\": \"ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd\", \"files\": {}}",
+        "dest": "cargo/vendor/combine-4.6.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.4.0.crate",
-        "sha256": "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363",
-        "dest": "cargo/vendor/concurrent-queue-2.4.0"
+        "url": "https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.5.0.crate",
+        "sha256": "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973",
+        "dest": "cargo/vendor/concurrent-queue-2.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363\", \"files\": {}}",
-        "dest": "cargo/vendor/concurrent-queue-2.4.0",
+        "contents": "{\"package\": \"4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973\", \"files\": {}}",
+        "dest": "cargo/vendor/concurrent-queue-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1276,40 +1289,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/const-field-offset/const-field-offset-0.1.3.crate",
-        "sha256": "6304465f16f463cddc572b737c3df93576edd3a6b53f057bd8beeb29f4ef8dfd",
-        "dest": "cargo/vendor/const-field-offset-0.1.3"
+        "url": "https://static.crates.io/crates/const-field-offset/const-field-offset-0.1.5.crate",
+        "sha256": "91fcde4ca1211b5a94b573083c472ee19e86b19a441913f66e1cc5c41daf0255",
+        "dest": "cargo/vendor/const-field-offset-0.1.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6304465f16f463cddc572b737c3df93576edd3a6b53f057bd8beeb29f4ef8dfd\", \"files\": {}}",
-        "dest": "cargo/vendor/const-field-offset-0.1.3",
+        "contents": "{\"package\": \"91fcde4ca1211b5a94b573083c472ee19e86b19a441913f66e1cc5c41daf0255\", \"files\": {}}",
+        "dest": "cargo/vendor/const-field-offset-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/const-field-offset-macro/const-field-offset-macro-0.1.3.crate",
-        "sha256": "57aaaad9185d3bcb3afe63549d8ba60b2fb0ea8dc2da83f62dd56805edf56fd1",
-        "dest": "cargo/vendor/const-field-offset-macro-0.1.3"
+        "url": "https://static.crates.io/crates/const-field-offset-macro/const-field-offset-macro-0.1.5.crate",
+        "sha256": "5387f5bbc9e9e6c96436ea125afa12614cebf8ac67f49abc08c1e7a891466c90",
+        "dest": "cargo/vendor/const-field-offset-macro-0.1.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"57aaaad9185d3bcb3afe63549d8ba60b2fb0ea8dc2da83f62dd56805edf56fd1\", \"files\": {}}",
-        "dest": "cargo/vendor/const-field-offset-macro-0.1.3",
+        "contents": "{\"package\": \"5387f5bbc9e9e6c96436ea125afa12614cebf8ac67f49abc08c1e7a891466c90\", \"files\": {}}",
+        "dest": "cargo/vendor/const-field-offset-macro-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/const_fn/const_fn-0.4.9.crate",
-        "sha256": "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935",
-        "dest": "cargo/vendor/const_fn-0.4.9"
+        "url": "https://static.crates.io/crates/const_fn/const_fn-0.4.10.crate",
+        "sha256": "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d",
+        "dest": "cargo/vendor/const_fn-0.4.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935\", \"files\": {}}",
-        "dest": "cargo/vendor/const_fn-0.4.9",
+        "contents": "{\"package\": \"373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d\", \"files\": {}}",
+        "dest": "cargo/vendor/const_fn-0.4.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1328,14 +1341,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/constant_time_eq/constant_time_eq-0.3.0.crate",
-        "sha256": "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2",
-        "dest": "cargo/vendor/constant_time_eq-0.3.0"
+        "url": "https://static.crates.io/crates/constant_time_eq/constant_time_eq-0.3.1.crate",
+        "sha256": "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6",
+        "dest": "cargo/vendor/constant_time_eq-0.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2\", \"files\": {}}",
-        "dest": "cargo/vendor/constant_time_eq-0.3.0",
+        "contents": "{\"package\": \"7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6\", \"files\": {}}",
+        "dest": "cargo/vendor/constant_time_eq-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1380,27 +1393,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.6.crate",
-        "sha256": "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f",
-        "dest": "cargo/vendor/core-foundation-sys-0.8.6"
+        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.10.0.crate",
+        "sha256": "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63",
+        "dest": "cargo/vendor/core-foundation-0.10.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f\", \"files\": {}}",
-        "dest": "cargo/vendor/core-foundation-sys-0.8.6",
+        "contents": "{\"package\": \"b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-0.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.23.1.crate",
-        "sha256": "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212",
-        "dest": "cargo/vendor/core-graphics-0.23.1"
+        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.7.crate",
+        "sha256": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212\", \"files\": {}}",
-        "dest": "cargo/vendor/core-graphics-0.23.1",
+        "contents": "{\"package\": \"773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.23.2.crate",
+        "sha256": "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081",
+        "dest": "cargo/vendor/core-graphics-0.23.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-0.23.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.24.0.crate",
+        "sha256": "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1",
+        "dest": "cargo/vendor/core-graphics-0.24.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-0.24.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1414,6 +1453,19 @@
         "type": "inline",
         "contents": "{\"package\": \"45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf\", \"files\": {}}",
         "dest": "cargo/vendor/core-graphics-types-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.2.0.crate",
+        "sha256": "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb",
+        "dest": "cargo/vendor/core-graphics-types-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-types-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1458,53 +1510,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.12.crate",
-        "sha256": "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504",
-        "dest": "cargo/vendor/cpufeatures-0.2.12"
+        "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.14.crate",
+        "sha256": "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0",
+        "dest": "cargo/vendor/cpufeatures-0.2.14"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504\", \"files\": {}}",
-        "dest": "cargo/vendor/cpufeatures-0.2.12",
+        "contents": "{\"package\": \"608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0\", \"files\": {}}",
+        "dest": "cargo/vendor/cpufeatures-0.2.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.4.0.crate",
-        "sha256": "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa",
-        "dest": "cargo/vendor/crc32fast-1.4.0"
+        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.4.2.crate",
+        "sha256": "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3",
+        "dest": "cargo/vendor/crc32fast-1.4.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa\", \"files\": {}}",
-        "dest": "cargo/vendor/crc32fast-1.4.0",
+        "contents": "{\"package\": \"a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3\", \"files\": {}}",
+        "dest": "cargo/vendor/crc32fast-1.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/critical-section/critical-section-1.1.2.crate",
-        "sha256": "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216",
-        "dest": "cargo/vendor/critical-section-1.1.2"
+        "url": "https://static.crates.io/crates/critical-section/critical-section-1.1.3.crate",
+        "sha256": "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242",
+        "dest": "cargo/vendor/critical-section-1.1.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216\", \"files\": {}}",
-        "dest": "cargo/vendor/critical-section-1.1.2",
+        "contents": "{\"package\": \"f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242\", \"files\": {}}",
+        "dest": "cargo/vendor/critical-section-1.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.11.crate",
-        "sha256": "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b",
-        "dest": "cargo/vendor/crossbeam-channel-0.5.11"
+        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.13.crate",
+        "sha256": "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.13"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-channel-0.5.11",
+        "contents": "{\"package\": \"33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1549,14 +1601,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.19.crate",
-        "sha256": "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345",
-        "dest": "cargo/vendor/crossbeam-utils-0.8.19"
+        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.20.crate",
+        "sha256": "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.20"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-utils-0.8.19",
+        "contents": "{\"package\": \"22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1588,40 +1640,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/css-color-parser2/css-color-parser2-1.0.1.crate",
-        "sha256": "cf8ed1639f4b56ec6f31d007ff66ce4a13099dce5a9995d48368a30d62bf04bd",
-        "dest": "cargo/vendor/css-color-parser2-1.0.1"
+        "url": "https://static.crates.io/crates/ctor-lite/ctor-lite-0.1.0.crate",
+        "sha256": "1f791803201ab277ace03903de1594460708d2d54df6053f2d9e82f592b19e3b",
+        "dest": "cargo/vendor/ctor-lite-0.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cf8ed1639f4b56ec6f31d007ff66ce4a13099dce5a9995d48368a30d62bf04bd\", \"files\": {}}",
-        "dest": "cargo/vendor/css-color-parser2-1.0.1",
+        "contents": "{\"package\": \"1f791803201ab277ace03903de1594460708d2d54df6053f2d9e82f592b19e3b\", \"files\": {}}",
+        "dest": "cargo/vendor/ctor-lite-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ctor/ctor-0.2.6.crate",
-        "sha256": "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e",
-        "dest": "cargo/vendor/ctor-0.2.6"
+        "url": "https://static.crates.io/crates/ctrlc/ctrlc-3.4.5.crate",
+        "sha256": "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3",
+        "dest": "cargo/vendor/ctrlc-3.4.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e\", \"files\": {}}",
-        "dest": "cargo/vendor/ctor-0.2.6",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ctrlc/ctrlc-3.4.2.crate",
-        "sha256": "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b",
-        "dest": "cargo/vendor/ctrlc-3.4.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b\", \"files\": {}}",
-        "dest": "cargo/vendor/ctrlc-3.4.2",
+        "contents": "{\"package\": \"90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3\", \"files\": {}}",
+        "dest": "cargo/vendor/ctrlc-3.4.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1705,14 +1744,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/data-encoding/data-encoding-2.5.0.crate",
-        "sha256": "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5",
-        "dest": "cargo/vendor/data-encoding-2.5.0"
+        "url": "https://static.crates.io/crates/data-encoding/data-encoding-2.6.0.crate",
+        "sha256": "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2",
+        "dest": "cargo/vendor/data-encoding-2.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5\", \"files\": {}}",
-        "dest": "cargo/vendor/data-encoding-2.5.0",
+        "contents": "{\"package\": \"e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2\", \"files\": {}}",
+        "dest": "cargo/vendor/data-encoding-2.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1783,40 +1822,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/derivative/derivative-2.2.0.crate",
-        "sha256": "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b",
-        "dest": "cargo/vendor/derivative-2.2.0"
+        "url": "https://static.crates.io/crates/derive_more/derive_more-0.99.18.crate",
+        "sha256": "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce",
+        "dest": "cargo/vendor/derive_more-0.99.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b\", \"files\": {}}",
-        "dest": "cargo/vendor/derivative-2.2.0",
+        "contents": "{\"package\": \"5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-0.99.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/derive_more/derive_more-0.99.17.crate",
-        "sha256": "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321",
-        "dest": "cargo/vendor/derive_more-0.99.17"
+        "url": "https://static.crates.io/crates/derive_utils/derive_utils-0.14.2.crate",
+        "sha256": "65f152f4b8559c4da5d574bafc7af85454d706b4c5fe8b530d508cacbb6807ea",
+        "dest": "cargo/vendor/derive_utils-0.14.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321\", \"files\": {}}",
-        "dest": "cargo/vendor/derive_more-0.99.17",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/derive_utils/derive_utils-0.14.1.crate",
-        "sha256": "61bb5a1014ce6dfc2a378578509abe775a5aa06bff584a547555d9efdb81b926",
-        "dest": "cargo/vendor/derive_utils-0.14.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"61bb5a1014ce6dfc2a378578509abe775a5aa06bff584a547555d9efdb81b926\", \"files\": {}}",
-        "dest": "cargo/vendor/derive_utils-0.14.1",
+        "contents": "{\"package\": \"65f152f4b8559c4da5d574bafc7af85454d706b4c5fe8b530d508cacbb6807ea\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_utils-0.14.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1874,14 +1900,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.4.crate",
-        "sha256": "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d",
-        "dest": "cargo/vendor/displaydoc-0.2.4"
+        "url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.5.crate",
+        "sha256": "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0",
+        "dest": "cargo/vendor/displaydoc-0.2.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d\", \"files\": {}}",
-        "dest": "cargo/vendor/displaydoc-0.2.4",
+        "contents": "{\"package\": \"97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0\", \"files\": {}}",
+        "dest": "cargo/vendor/displaydoc-0.2.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1913,66 +1939,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/downcast-rs/downcast-rs-1.2.0.crate",
-        "sha256": "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650",
-        "dest": "cargo/vendor/downcast-rs-1.2.0"
+        "url": "https://static.crates.io/crates/downcast-rs/downcast-rs-1.2.1.crate",
+        "sha256": "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2",
+        "dest": "cargo/vendor/downcast-rs-1.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650\", \"files\": {}}",
-        "dest": "cargo/vendor/downcast-rs-1.2.0",
+        "contents": "{\"package\": \"75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2\", \"files\": {}}",
+        "dest": "cargo/vendor/downcast-rs-1.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/drm/drm-0.9.0.crate",
-        "sha256": "edf9159ef4bcecd0c5e4cbeb573b8d0037493403d542780dba5d840bbf9df56f",
-        "dest": "cargo/vendor/drm-0.9.0"
+        "url": "https://static.crates.io/crates/dpi/dpi-0.1.1.crate",
+        "sha256": "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53",
+        "dest": "cargo/vendor/dpi-0.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"edf9159ef4bcecd0c5e4cbeb573b8d0037493403d542780dba5d840bbf9df56f\", \"files\": {}}",
-        "dest": "cargo/vendor/drm-0.9.0",
+        "contents": "{\"package\": \"f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53\", \"files\": {}}",
+        "dest": "cargo/vendor/dpi-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/drm/drm-0.11.1.crate",
-        "sha256": "a0f8a69e60d75ae7dab4ef26a59ca99f2a89d4c142089b537775ae0c198bdcde",
-        "dest": "cargo/vendor/drm-0.11.1"
+        "url": "https://static.crates.io/crates/drm/drm-0.12.0.crate",
+        "sha256": "98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1",
+        "dest": "cargo/vendor/drm-0.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a0f8a69e60d75ae7dab4ef26a59ca99f2a89d4c142089b537775ae0c198bdcde\", \"files\": {}}",
-        "dest": "cargo/vendor/drm-0.11.1",
+        "contents": "{\"package\": \"98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/drm-ffi/drm-ffi-0.5.0.crate",
-        "sha256": "1352481b7b90e27a8a1bf8ef6b33cf18b98dba7c410e75c24bb3eef2f0d8d525",
-        "dest": "cargo/vendor/drm-ffi-0.5.0"
+        "url": "https://static.crates.io/crates/drm-ffi/drm-ffi-0.8.0.crate",
+        "sha256": "97c98727e48b7ccb4f4aea8cfe881e5b07f702d17b7875991881b41af7278d53",
+        "dest": "cargo/vendor/drm-ffi-0.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1352481b7b90e27a8a1bf8ef6b33cf18b98dba7c410e75c24bb3eef2f0d8d525\", \"files\": {}}",
-        "dest": "cargo/vendor/drm-ffi-0.5.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/drm-ffi/drm-ffi-0.7.1.crate",
-        "sha256": "41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6",
-        "dest": "cargo/vendor/drm-ffi-0.7.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6\", \"files\": {}}",
-        "dest": "cargo/vendor/drm-ffi-0.7.1",
+        "contents": "{\"package\": \"97c98727e48b7ccb4f4aea8cfe881e5b07f702d17b7875991881b41af7278d53\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-ffi-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1991,53 +2004,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/drm-sys/drm-sys-0.4.0.crate",
-        "sha256": "1369f1679d6b706d234c4c1e0613c415c2c74b598a09ad28080ba2474b72e42d",
-        "dest": "cargo/vendor/drm-sys-0.4.0"
+        "url": "https://static.crates.io/crates/drm-sys/drm-sys-0.7.0.crate",
+        "sha256": "fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986",
+        "dest": "cargo/vendor/drm-sys-0.7.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1369f1679d6b706d234c4c1e0613c415c2c74b598a09ad28080ba2474b72e42d\", \"files\": {}}",
-        "dest": "cargo/vendor/drm-sys-0.4.0",
+        "contents": "{\"package\": \"fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-sys-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/drm-sys/drm-sys-0.6.1.crate",
-        "sha256": "2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176",
-        "dest": "cargo/vendor/drm-sys-0.6.1"
+        "url": "https://static.crates.io/crates/dwrote/dwrote-0.11.1.crate",
+        "sha256": "2da3498378ed373237bdef1eddcc64e7be2d3ba4841f4c22a998e81cadeea83c",
+        "dest": "cargo/vendor/dwrote-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176\", \"files\": {}}",
-        "dest": "cargo/vendor/drm-sys-0.6.1",
+        "contents": "{\"package\": \"2da3498378ed373237bdef1eddcc64e7be2d3ba4841f4c22a998e81cadeea83c\", \"files\": {}}",
+        "dest": "cargo/vendor/dwrote-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/dwrote/dwrote-0.11.0.crate",
-        "sha256": "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b",
-        "dest": "cargo/vendor/dwrote-0.11.0"
+        "url": "https://static.crates.io/crates/either/either-1.13.0.crate",
+        "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+        "dest": "cargo/vendor/either-1.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b\", \"files\": {}}",
-        "dest": "cargo/vendor/dwrote-0.11.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/either/either-1.10.0.crate",
-        "sha256": "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a",
-        "dest": "cargo/vendor/either-1.10.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a\", \"files\": {}}",
-        "dest": "cargo/vendor/either-1.10.0",
+        "contents": "{\"package\": \"60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0\", \"files\": {}}",
+        "dest": "cargo/vendor/either-1.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2056,53 +2056,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.33.crate",
-        "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1",
-        "dest": "cargo/vendor/encoding_rs-0.8.33"
+        "url": "https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.34.crate",
+        "sha256": "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59",
+        "dest": "cargo/vendor/encoding_rs-0.8.34"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1\", \"files\": {}}",
-        "dest": "cargo/vendor/encoding_rs-0.8.33",
+        "contents": "{\"package\": \"b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59\", \"files\": {}}",
+        "dest": "cargo/vendor/encoding_rs-0.8.34",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/enumflags2/enumflags2-0.7.9.crate",
-        "sha256": "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d",
-        "dest": "cargo/vendor/enumflags2-0.7.9"
+        "url": "https://static.crates.io/crates/endi/endi-1.1.0.crate",
+        "sha256": "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf",
+        "dest": "cargo/vendor/endi-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d\", \"files\": {}}",
-        "dest": "cargo/vendor/enumflags2-0.7.9",
+        "contents": "{\"package\": \"a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf\", \"files\": {}}",
+        "dest": "cargo/vendor/endi-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.9.crate",
-        "sha256": "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4",
-        "dest": "cargo/vendor/enumflags2_derive-0.7.9"
+        "url": "https://static.crates.io/crates/enumflags2/enumflags2-0.7.10.crate",
+        "sha256": "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d",
+        "dest": "cargo/vendor/enumflags2-0.7.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4\", \"files\": {}}",
-        "dest": "cargo/vendor/enumflags2_derive-0.7.9",
+        "contents": "{\"package\": \"d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d\", \"files\": {}}",
+        "dest": "cargo/vendor/enumflags2-0.7.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/enumn/enumn-0.1.13.crate",
-        "sha256": "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42",
-        "dest": "cargo/vendor/enumn-0.1.13"
+        "url": "https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.10.crate",
+        "sha256": "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8",
+        "dest": "cargo/vendor/enumflags2_derive-0.7.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42\", \"files\": {}}",
-        "dest": "cargo/vendor/enumn-0.1.13",
+        "contents": "{\"package\": \"de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8\", \"files\": {}}",
+        "dest": "cargo/vendor/enumflags2_derive-0.7.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enumn/enumn-0.1.14.crate",
+        "sha256": "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38",
+        "dest": "cargo/vendor/enumn-0.1.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38\", \"files\": {}}",
+        "dest": "cargo/vendor/enumn-0.1.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2121,105 +2134,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/errno/errno-0.3.8.crate",
-        "sha256": "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245",
-        "dest": "cargo/vendor/errno-0.3.8"
+        "url": "https://static.crates.io/crates/errno/errno-0.3.9.crate",
+        "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba",
+        "dest": "cargo/vendor/errno-0.3.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245\", \"files\": {}}",
-        "dest": "cargo/vendor/errno-0.3.8",
+        "contents": "{\"package\": \"534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-0.3.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/euclid/euclid-0.22.9.crate",
-        "sha256": "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787",
-        "dest": "cargo/vendor/euclid-0.22.9"
+        "url": "https://static.crates.io/crates/euclid/euclid-0.22.11.crate",
+        "sha256": "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48",
+        "dest": "cargo/vendor/euclid-0.22.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787\", \"files\": {}}",
-        "dest": "cargo/vendor/euclid-0.22.9",
+        "contents": "{\"package\": \"ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48\", \"files\": {}}",
+        "dest": "cargo/vendor/euclid-0.22.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/event-listener/event-listener-2.5.3.crate",
-        "sha256": "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0",
-        "dest": "cargo/vendor/event-listener-2.5.3"
+        "url": "https://static.crates.io/crates/event-listener/event-listener-5.3.1.crate",
+        "sha256": "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba",
+        "dest": "cargo/vendor/event-listener-5.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0\", \"files\": {}}",
-        "dest": "cargo/vendor/event-listener-2.5.3",
+        "contents": "{\"package\": \"6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-5.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/event-listener/event-listener-3.1.0.crate",
-        "sha256": "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2",
-        "dest": "cargo/vendor/event-listener-3.1.0"
+        "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.5.2.crate",
+        "sha256": "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1",
+        "dest": "cargo/vendor/event-listener-strategy-0.5.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2\", \"files\": {}}",
-        "dest": "cargo/vendor/event-listener-3.1.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/event-listener/event-listener-4.0.3.crate",
-        "sha256": "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e",
-        "dest": "cargo/vendor/event-listener-4.0.3"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e\", \"files\": {}}",
-        "dest": "cargo/vendor/event-listener-4.0.3",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/event-listener/event-listener-5.1.0.crate",
-        "sha256": "b7ad6fd685ce13acd6d9541a30f6db6567a7a24c9ffd4ba2955d29e3f22c8b27",
-        "dest": "cargo/vendor/event-listener-5.1.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"b7ad6fd685ce13acd6d9541a30f6db6567a7a24c9ffd4ba2955d29e3f22c8b27\", \"files\": {}}",
-        "dest": "cargo/vendor/event-listener-5.1.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.4.0.crate",
-        "sha256": "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3",
-        "dest": "cargo/vendor/event-listener-strategy-0.4.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3\", \"files\": {}}",
-        "dest": "cargo/vendor/event-listener-strategy-0.4.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.5.0.crate",
-        "sha256": "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291",
-        "dest": "cargo/vendor/event-listener-strategy-0.5.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291\", \"files\": {}}",
-        "dest": "cargo/vendor/event-listener-strategy-0.5.0",
+        "contents": "{\"package\": \"0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-strategy-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2238,40 +2199,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fastrand/fastrand-1.9.0.crate",
-        "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
-        "dest": "cargo/vendor/fastrand-1.9.0"
+        "url": "https://static.crates.io/crates/extended/extended-0.1.0.crate",
+        "sha256": "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365",
+        "dest": "cargo/vendor/extended-0.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be\", \"files\": {}}",
-        "dest": "cargo/vendor/fastrand-1.9.0",
+        "contents": "{\"package\": \"af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365\", \"files\": {}}",
+        "dest": "cargo/vendor/extended-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fastrand/fastrand-2.0.1.crate",
-        "sha256": "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5",
-        "dest": "cargo/vendor/fastrand-2.0.1"
+        "url": "https://static.crates.io/crates/fastrand/fastrand-2.1.1.crate",
+        "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
+        "dest": "cargo/vendor/fastrand-2.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5\", \"files\": {}}",
-        "dest": "cargo/vendor/fastrand-2.0.1",
+        "contents": "{\"package\": \"e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6\", \"files\": {}}",
+        "dest": "cargo/vendor/fastrand-2.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fax/fax-0.2.0.crate",
-        "sha256": "b2cec1797683c06c2f3de5edb3fde4d99c70e96f3204f6aaff944078353e5c55",
-        "dest": "cargo/vendor/fax-0.2.0"
+        "url": "https://static.crates.io/crates/fax/fax-0.2.4.crate",
+        "sha256": "b03e33ad0e71af414ef9d2b0a94d23ff59115bb068e6a6a06c0952f2c22ffd77",
+        "dest": "cargo/vendor/fax-0.2.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b2cec1797683c06c2f3de5edb3fde4d99c70e96f3204f6aaff944078353e5c55\", \"files\": {}}",
-        "dest": "cargo/vendor/fax-0.2.0",
+        "contents": "{\"package\": \"b03e33ad0e71af414ef9d2b0a94d23ff59115bb068e6a6a06c0952f2c22ffd77\", \"files\": {}}",
+        "dest": "cargo/vendor/fax-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2290,27 +2251,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.4.crate",
-        "sha256": "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645",
-        "dest": "cargo/vendor/fdeflate-0.3.4"
+        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.5.crate",
+        "sha256": "d8090f921a24b04994d9929e204f50b498a33ea6ba559ffaa05e04f7ee7fb5ab",
+        "dest": "cargo/vendor/fdeflate-0.3.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645\", \"files\": {}}",
-        "dest": "cargo/vendor/fdeflate-0.3.4",
+        "contents": "{\"package\": \"d8090f921a24b04994d9929e204f50b498a33ea6ba559ffaa05e04f7ee7fb5ab\", \"files\": {}}",
+        "dest": "cargo/vendor/fdeflate-0.3.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/femtovg/femtovg-0.8.2.crate",
-        "sha256": "18ab822e58e8bc2b89840dc5dde49afe39302e129c60d39c8520200c085404a7",
-        "dest": "cargo/vendor/femtovg-0.8.2"
+        "url": "https://static.crates.io/crates/femtovg/femtovg-0.9.2.crate",
+        "sha256": "47921d14afc4daad9bedc926099bc6edcaa23e37a957448f86cdefcbafe2f632",
+        "dest": "cargo/vendor/femtovg-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"18ab822e58e8bc2b89840dc5dde49afe39302e129c60d39c8520200c085404a7\", \"files\": {}}",
-        "dest": "cargo/vendor/femtovg-0.8.2",
+        "contents": "{\"package\": \"47921d14afc4daad9bedc926099bc6edcaa23e37a957448f86cdefcbafe2f632\", \"files\": {}}",
+        "dest": "cargo/vendor/femtovg-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2342,14 +2303,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/filetime/filetime-0.2.23.crate",
-        "sha256": "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd",
-        "dest": "cargo/vendor/filetime-0.2.23"
+        "url": "https://static.crates.io/crates/filetime/filetime-0.2.25.crate",
+        "sha256": "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586",
+        "dest": "cargo/vendor/filetime-0.2.25"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd\", \"files\": {}}",
-        "dest": "cargo/vendor/filetime-0.2.23",
+        "contents": "{\"package\": \"35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586\", \"files\": {}}",
+        "dest": "cargo/vendor/filetime-0.2.25",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2368,27 +2329,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/finl_unicode/finl_unicode-1.2.0.crate",
-        "sha256": "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6",
-        "dest": "cargo/vendor/finl_unicode-1.2.0"
+        "url": "https://static.crates.io/crates/flate2/flate2-1.0.34.crate",
+        "sha256": "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0",
+        "dest": "cargo/vendor/flate2-1.0.34"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6\", \"files\": {}}",
-        "dest": "cargo/vendor/finl_unicode-1.2.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/flate2/flate2-1.0.28.crate",
-        "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
-        "dest": "cargo/vendor/flate2-1.0.28"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e\", \"files\": {}}",
-        "dest": "cargo/vendor/flate2-1.0.28",
+        "contents": "{\"package\": \"a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0\", \"files\": {}}",
+        "dest": "cargo/vendor/flate2-1.0.34",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2407,27 +2355,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fluent/fluent-0.16.0.crate",
-        "sha256": "61f69378194459db76abd2ce3952b790db103ceb003008d3d50d97c41ff847a7",
-        "dest": "cargo/vendor/fluent-0.16.0"
+        "url": "https://static.crates.io/crates/fluent/fluent-0.16.1.crate",
+        "sha256": "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a",
+        "dest": "cargo/vendor/fluent-0.16.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"61f69378194459db76abd2ce3952b790db103ceb003008d3d50d97c41ff847a7\", \"files\": {}}",
-        "dest": "cargo/vendor/fluent-0.16.0",
+        "contents": "{\"package\": \"bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a\", \"files\": {}}",
+        "dest": "cargo/vendor/fluent-0.16.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fluent-bundle/fluent-bundle-0.15.2.crate",
-        "sha256": "e242c601dec9711505f6d5bbff5bedd4b61b2469f2e8bb8e57ee7c9747a87ffd",
-        "dest": "cargo/vendor/fluent-bundle-0.15.2"
+        "url": "https://static.crates.io/crates/fluent-bundle/fluent-bundle-0.15.3.crate",
+        "sha256": "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493",
+        "dest": "cargo/vendor/fluent-bundle-0.15.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e242c601dec9711505f6d5bbff5bedd4b61b2469f2e8bb8e57ee7c9747a87ffd\", \"files\": {}}",
-        "dest": "cargo/vendor/fluent-bundle-0.15.2",
+        "contents": "{\"package\": \"7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493\", \"files\": {}}",
+        "dest": "cargo/vendor/fluent-bundle-0.15.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2446,14 +2394,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fluent-syntax/fluent-syntax-0.11.0.crate",
-        "sha256": "c0abed97648395c902868fee9026de96483933faa54ea3b40d652f7dfe61ca78",
-        "dest": "cargo/vendor/fluent-syntax-0.11.0"
+        "url": "https://static.crates.io/crates/fluent-syntax/fluent-syntax-0.11.1.crate",
+        "sha256": "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d",
+        "dest": "cargo/vendor/fluent-syntax-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c0abed97648395c902868fee9026de96483933faa54ea3b40d652f7dfe61ca78\", \"files\": {}}",
-        "dest": "cargo/vendor/fluent-syntax-0.11.0",
+        "contents": "{\"package\": \"2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d\", \"files\": {}}",
+        "dest": "cargo/vendor/fluent-syntax-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2485,40 +2433,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fontconfig-parser/fontconfig-parser-0.5.6.crate",
-        "sha256": "6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d",
-        "dest": "cargo/vendor/fontconfig-parser-0.5.6"
+        "url": "https://static.crates.io/crates/fontconfig-parser/fontconfig-parser-0.5.7.crate",
+        "sha256": "c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7",
+        "dest": "cargo/vendor/fontconfig-parser-0.5.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d\", \"files\": {}}",
-        "dest": "cargo/vendor/fontconfig-parser-0.5.6",
+        "contents": "{\"package\": \"c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7\", \"files\": {}}",
+        "dest": "cargo/vendor/fontconfig-parser-0.5.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fontdb/fontdb-0.16.1.crate",
-        "sha256": "3890d0893c8253d3eb98337af18b3e1a10a9b2958f2a164b53a93fb3a3049e72",
-        "dest": "cargo/vendor/fontdb-0.16.1"
+        "url": "https://static.crates.io/crates/fontdb/fontdb-0.18.0.crate",
+        "sha256": "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770",
+        "dest": "cargo/vendor/fontdb-0.18.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3890d0893c8253d3eb98337af18b3e1a10a9b2958f2a164b53a93fb3a3049e72\", \"files\": {}}",
-        "dest": "cargo/vendor/fontdb-0.16.1",
+        "contents": "{\"package\": \"e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770\", \"files\": {}}",
+        "dest": "cargo/vendor/fontdb-0.18.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fontdue/fontdue-0.8.0.crate",
-        "sha256": "9099a2f86b8e674b75d03ff154b3fe4c5208ed249ced8d69cc313a9fa40bb488",
-        "dest": "cargo/vendor/fontdue-0.8.0"
+        "url": "https://static.crates.io/crates/fontdue/fontdue-0.9.2.crate",
+        "sha256": "efe23d02309319171d00d794c9ff48d4f903c0e481375b1b04b017470838af04",
+        "dest": "cargo/vendor/fontdue-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9099a2f86b8e674b75d03ff154b3fe4c5208ed249ced8d69cc313a9fa40bb488\", \"files\": {}}",
-        "dest": "cargo/vendor/fontdue-0.8.0",
+        "contents": "{\"package\": \"efe23d02309319171d00d794c9ff48d4f903c0e481375b1b04b017470838af04\", \"files\": {}}",
+        "dest": "cargo/vendor/fontdue-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2680,27 +2628,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-lite/futures-lite-1.13.0.crate",
-        "sha256": "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce",
-        "dest": "cargo/vendor/futures-lite-1.13.0"
+        "url": "https://static.crates.io/crates/futures-lite/futures-lite-2.3.0.crate",
+        "sha256": "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5",
+        "dest": "cargo/vendor/futures-lite-2.3.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-lite-1.13.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-lite/futures-lite-2.2.0.crate",
-        "sha256": "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba",
-        "dest": "cargo/vendor/futures-lite-2.2.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-lite-2.2.0",
+        "contents": "{\"package\": \"52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-lite-2.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2758,92 +2693,79 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gbm/gbm-0.12.0.crate",
-        "sha256": "f2ec389cda876966cf824111bf6e533fb934c711d473498279964a990853b3c6",
-        "dest": "cargo/vendor/gbm-0.12.0"
+        "url": "https://static.crates.io/crates/gbm/gbm-0.15.0.crate",
+        "sha256": "45bf55ba6dd53ad0ac115046ff999c5324c283444ee6e0be82454c4e8eb2f36a",
+        "dest": "cargo/vendor/gbm-0.15.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f2ec389cda876966cf824111bf6e533fb934c711d473498279964a990853b3c6\", \"files\": {}}",
-        "dest": "cargo/vendor/gbm-0.12.0",
+        "contents": "{\"package\": \"45bf55ba6dd53ad0ac115046ff999c5324c283444ee6e0be82454c4e8eb2f36a\", \"files\": {}}",
+        "dest": "cargo/vendor/gbm-0.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gbm-sys/gbm-sys-0.2.2.crate",
-        "sha256": "b63eba9b9b7a231514482deb08759301c9f9f049ac6869403f381834ebfeaf67",
-        "dest": "cargo/vendor/gbm-sys-0.2.2"
+        "url": "https://static.crates.io/crates/gbm-sys/gbm-sys-0.3.1.crate",
+        "sha256": "a9cc2f64de9fa707b5c6b2d2f10d7a7e49e845018a9f5685891eb40d3bab2538",
+        "dest": "cargo/vendor/gbm-sys-0.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b63eba9b9b7a231514482deb08759301c9f9f049ac6869403f381834ebfeaf67\", \"files\": {}}",
-        "dest": "cargo/vendor/gbm-sys-0.2.2",
+        "contents": "{\"package\": \"a9cc2f64de9fa707b5c6b2d2f10d7a7e49e845018a9f5685891eb40d3bab2538\", \"files\": {}}",
+        "dest": "cargo/vendor/gbm-sys-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.19.2.crate",
-        "sha256": "f6a23f8a0b5090494fd04924662d463f8386cc678dd3915015a838c1a3679b92",
-        "dest": "cargo/vendor/gdk-pixbuf-0.19.2"
+        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.19.8.crate",
+        "sha256": "624eaba126021103c7339b2e179ae4ee8cdab842daab419040710f38ed9f8699",
+        "dest": "cargo/vendor/gdk-pixbuf-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f6a23f8a0b5090494fd04924662d463f8386cc678dd3915015a838c1a3679b92\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk-pixbuf-0.19.2",
+        "contents": "{\"package\": \"624eaba126021103c7339b2e179ae4ee8cdab842daab419040710f38ed9f8699\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.19.0.crate",
-        "sha256": "3dcbd04c1b2c4834cc008b4828bc917d062483b88d26effde6342e5622028f96",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.0"
+        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.19.8.crate",
+        "sha256": "4efa05a4f83c8cc50eb4d883787b919b85e5f1d8dd10b5a1df53bf5689782379",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3dcbd04c1b2c4834cc008b4828bc917d062483b88d26effde6342e5622028f96\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.0",
+        "contents": "{\"package\": \"4efa05a4f83c8cc50eb4d883787b919b85e5f1d8dd10b5a1df53bf5689782379\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk4/gdk4-0.8.0.crate",
-        "sha256": "6771942f85a2beaa220c64739395e4401b9fab4a52aba9b503fa1e6ed4d4d806",
-        "dest": "cargo/vendor/gdk4-0.8.0"
+        "url": "https://static.crates.io/crates/gdk4/gdk4-0.8.2.crate",
+        "sha256": "db265c9dd42d6a371e09e52deab3a84808427198b86ac792d75fd35c07990a07",
+        "dest": "cargo/vendor/gdk4-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6771942f85a2beaa220c64739395e4401b9fab4a52aba9b503fa1e6ed4d4d806\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk4-0.8.0",
+        "contents": "{\"package\": \"db265c9dd42d6a371e09e52deab3a84808427198b86ac792d75fd35c07990a07\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk4-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.8.0.crate",
-        "sha256": "1eb95854fab65072023a7814434f003db571d6e45c287c0b0c540c1c78bdf6ae",
-        "dest": "cargo/vendor/gdk4-sys-0.8.0"
+        "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.8.2.crate",
+        "sha256": "c9418fb4e8a67074919fe7604429c45aa74eb9df82e7ca529767c6d4e9dc66dd",
+        "dest": "cargo/vendor/gdk4-sys-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1eb95854fab65072023a7814434f003db571d6e45c287c0b0c540c1c78bdf6ae\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk4-sys-0.8.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/generational-arena/generational-arena-0.2.9.crate",
-        "sha256": "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7",
-        "dest": "cargo/vendor/generational-arena-0.2.9"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7\", \"files\": {}}",
-        "dest": "cargo/vendor/generational-arena-0.2.9",
+        "contents": "{\"package\": \"c9418fb4e8a67074919fe7604429c45aa74eb9df82e7ca529767c6d4e9dc66dd\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk4-sys-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2875,19 +2797,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gethostname/gethostname-0.3.0.crate",
-        "sha256": "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177",
-        "dest": "cargo/vendor/gethostname-0.3.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177\", \"files\": {}}",
-        "dest": "cargo/vendor/gethostname-0.3.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gethostname/gethostname-0.4.3.crate",
         "sha256": "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818",
         "dest": "cargo/vendor/gethostname-0.4.3"
@@ -2901,53 +2810,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.12.crate",
-        "sha256": "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5",
-        "dest": "cargo/vendor/getrandom-0.2.12"
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.15.crate",
+        "sha256": "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7",
+        "dest": "cargo/vendor/getrandom-0.2.15"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5\", \"files\": {}}",
-        "dest": "cargo/vendor/getrandom-0.2.12",
+        "contents": "{\"package\": \"c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.2.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gif/gif-0.12.0.crate",
-        "sha256": "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045",
-        "dest": "cargo/vendor/gif-0.12.0"
+        "url": "https://static.crates.io/crates/gif/gif-0.13.1.crate",
+        "sha256": "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2",
+        "dest": "cargo/vendor/gif-0.13.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045\", \"files\": {}}",
-        "dest": "cargo/vendor/gif-0.12.0",
+        "contents": "{\"package\": \"3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2\", \"files\": {}}",
+        "dest": "cargo/vendor/gif-0.13.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gio/gio-0.19.2.crate",
-        "sha256": "2eae10b27b6dd27e22ed0d812c6387deba295e6fc004a8b379e459b663b05a02",
-        "dest": "cargo/vendor/gio-0.19.2"
+        "url": "https://static.crates.io/crates/gio/gio-0.19.8.crate",
+        "sha256": "4c49f117d373ffcc98a35d114db5478bc223341cff53e39a5d6feced9e2ddffe",
+        "dest": "cargo/vendor/gio-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2eae10b27b6dd27e22ed0d812c6387deba295e6fc004a8b379e459b663b05a02\", \"files\": {}}",
-        "dest": "cargo/vendor/gio-0.19.2",
+        "contents": "{\"package\": \"4c49f117d373ffcc98a35d114db5478bc223341cff53e39a5d6feced9e2ddffe\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.19.0.crate",
-        "sha256": "bcf8e1d9219bb294636753d307b030c1e8a032062cba74f493c431a5c8b81ce4",
-        "dest": "cargo/vendor/gio-sys-0.19.0"
+        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.19.8.crate",
+        "sha256": "2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef",
+        "dest": "cargo/vendor/gio-sys-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bcf8e1d9219bb294636753d307b030c1e8a032062cba74f493c431a5c8b81ce4\", \"files\": {}}",
-        "dest": "cargo/vendor/gio-sys-0.19.0",
+        "contents": "{\"package\": \"2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-sys-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2966,40 +2875,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib/glib-0.19.2.crate",
-        "sha256": "ab9e86540b5d8402e905ad4ce7d6aa544092131ab564f3102175af176b90a053",
-        "dest": "cargo/vendor/glib-0.19.2"
+        "url": "https://static.crates.io/crates/glib/glib-0.19.9.crate",
+        "sha256": "39650279f135469465018daae0ba53357942a5212137515777d5fdca74984a44",
+        "dest": "cargo/vendor/glib-0.19.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ab9e86540b5d8402e905ad4ce7d6aa544092131ab564f3102175af176b90a053\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-0.19.2",
+        "contents": "{\"package\": \"39650279f135469465018daae0ba53357942a5212137515777d5fdca74984a44\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-0.19.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.19.2.crate",
-        "sha256": "0f5897ca27a83e4cdc7b4666850bade0a2e73e17689aabafcc9acddad9d823b8",
-        "dest": "cargo/vendor/glib-macros-0.19.2"
+        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.19.9.crate",
+        "sha256": "4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7",
+        "dest": "cargo/vendor/glib-macros-0.19.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0f5897ca27a83e4cdc7b4666850bade0a2e73e17689aabafcc9acddad9d823b8\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-macros-0.19.2",
+        "contents": "{\"package\": \"4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-macros-0.19.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.19.0.crate",
-        "sha256": "630f097773d7c7a0bb3258df4e8157b47dc98bbfa0e60ad9ab56174813feced4",
-        "dest": "cargo/vendor/glib-sys-0.19.0"
+        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.19.8.crate",
+        "sha256": "5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5",
+        "dest": "cargo/vendor/glib-sys-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"630f097773d7c7a0bb3258df4e8157b47dc98bbfa0e60ad9ab56174813feced4\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-sys-0.19.0",
+        "contents": "{\"package\": \"5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-sys-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3018,14 +2927,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/globalcache/globalcache-0.2.2.crate",
-        "sha256": "ccd40efe5b4f0021ca3c36a140cb365563be3c579653b573a5a8ac69bd6f9028",
-        "dest": "cargo/vendor/globalcache-0.2.2"
+        "url": "https://static.crates.io/crates/globalcache/globalcache-0.2.4.crate",
+        "sha256": "240a3059d86f2ba6859ac79f95ff94e65606abc775c1bc0ecf9b6590fb35dc04",
+        "dest": "cargo/vendor/globalcache-0.2.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ccd40efe5b4f0021ca3c36a140cb365563be3c579653b573a5a8ac69bd6f9028\", \"files\": {}}",
-        "dest": "cargo/vendor/globalcache-0.2.2",
+        "contents": "{\"package\": \"240a3059d86f2ba6859ac79f95ff94e65606abc775c1bc0ecf9b6590fb35dc04\", \"files\": {}}",
+        "dest": "cargo/vendor/globalcache-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3044,183 +2953,183 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glutin/glutin-0.31.3.crate",
-        "sha256": "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746",
-        "dest": "cargo/vendor/glutin-0.31.3"
+        "url": "https://static.crates.io/crates/glutin/glutin-0.32.1.crate",
+        "sha256": "ec69412a0bf07ea7607e638b415447857a808846c2b685a43c8aa18bc6d5e499",
+        "dest": "cargo/vendor/glutin-0.32.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746\", \"files\": {}}",
-        "dest": "cargo/vendor/glutin-0.31.3",
+        "contents": "{\"package\": \"ec69412a0bf07ea7607e638b415447857a808846c2b685a43c8aa18bc6d5e499\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin-0.32.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glutin-winit/glutin-winit-0.4.2.crate",
-        "sha256": "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735",
-        "dest": "cargo/vendor/glutin-winit-0.4.2"
+        "url": "https://static.crates.io/crates/glutin-winit/glutin-winit-0.5.0.crate",
+        "sha256": "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f",
+        "dest": "cargo/vendor/glutin-winit-0.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735\", \"files\": {}}",
-        "dest": "cargo/vendor/glutin-winit-0.4.2",
+        "contents": "{\"package\": \"85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin-winit-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glutin_egl_sys/glutin_egl_sys-0.6.0.crate",
-        "sha256": "77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd",
-        "dest": "cargo/vendor/glutin_egl_sys-0.6.0"
+        "url": "https://static.crates.io/crates/glutin_egl_sys/glutin_egl_sys-0.7.0.crate",
+        "sha256": "cae99fff4d2850dbe6fb8c1fa8e4fead5525bab715beaacfccf3fb994e01c827",
+        "dest": "cargo/vendor/glutin_egl_sys-0.7.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd\", \"files\": {}}",
-        "dest": "cargo/vendor/glutin_egl_sys-0.6.0",
+        "contents": "{\"package\": \"cae99fff4d2850dbe6fb8c1fa8e4fead5525bab715beaacfccf3fb994e01c827\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin_egl_sys-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glutin_glx_sys/glutin_glx_sys-0.5.0.crate",
-        "sha256": "a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f",
-        "dest": "cargo/vendor/glutin_glx_sys-0.5.0"
+        "url": "https://static.crates.io/crates/glutin_glx_sys/glutin_glx_sys-0.6.0.crate",
+        "sha256": "9c2b2d3918e76e18e08796b55eb64e8fe6ec67d5a6b2e2a7e2edce224ad24c63",
+        "dest": "cargo/vendor/glutin_glx_sys-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f\", \"files\": {}}",
-        "dest": "cargo/vendor/glutin_glx_sys-0.5.0",
+        "contents": "{\"package\": \"9c2b2d3918e76e18e08796b55eb64e8fe6ec67d5a6b2e2a7e2edce224ad24c63\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin_glx_sys-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glutin_wgl_sys/glutin_wgl_sys-0.5.0.crate",
-        "sha256": "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead",
-        "dest": "cargo/vendor/glutin_wgl_sys-0.5.0"
+        "url": "https://static.crates.io/crates/glutin_wgl_sys/glutin_wgl_sys-0.6.0.crate",
+        "sha256": "0a4e1951bbd9434a81aa496fe59ccc2235af3820d27b85f9314e279609211e2c",
+        "dest": "cargo/vendor/glutin_wgl_sys-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead\", \"files\": {}}",
-        "dest": "cargo/vendor/glutin_wgl_sys-0.5.0",
+        "contents": "{\"package\": \"0a4e1951bbd9434a81aa496fe59ccc2235af3820d27b85f9314e279609211e2c\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin_wgl_sys-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.19.0.crate",
-        "sha256": "c85e2b1080b9418dd0c58b498da3a5c826030343e0ef07bde6a955d28de54979",
-        "dest": "cargo/vendor/gobject-sys-0.19.0"
+        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.19.8.crate",
+        "sha256": "2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e",
+        "dest": "cargo/vendor/gobject-sys-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c85e2b1080b9418dd0c58b498da3a5c826030343e0ef07bde6a955d28de54979\", \"files\": {}}",
-        "dest": "cargo/vendor/gobject-sys-0.19.0",
+        "contents": "{\"package\": \"2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e\", \"files\": {}}",
+        "dest": "cargo/vendor/gobject-sys-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.19.2.crate",
-        "sha256": "99e4d388e96c5f29e2b2f67045d229ddf826d0a8d6d282f94ed3b34452222c91",
-        "dest": "cargo/vendor/graphene-rs-0.19.2"
+        "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.19.8.crate",
+        "sha256": "f5fb86031d24d9ec0a2a15978fc7a65d545a2549642cf1eb7c3dda358da42bcf",
+        "dest": "cargo/vendor/graphene-rs-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"99e4d388e96c5f29e2b2f67045d229ddf826d0a8d6d282f94ed3b34452222c91\", \"files\": {}}",
-        "dest": "cargo/vendor/graphene-rs-0.19.2",
+        "contents": "{\"package\": \"f5fb86031d24d9ec0a2a15978fc7a65d545a2549642cf1eb7c3dda358da42bcf\", \"files\": {}}",
+        "dest": "cargo/vendor/graphene-rs-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.19.0.crate",
-        "sha256": "236ed66cc9b18d8adf233716f75de803d0bf6fc806f60d14d948974a12e240d0",
-        "dest": "cargo/vendor/graphene-sys-0.19.0"
+        "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.19.8.crate",
+        "sha256": "2f530e0944bccba4b55065e9c69f4975ad691609191ebac16e13ab8e1f27af05",
+        "dest": "cargo/vendor/graphene-sys-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"236ed66cc9b18d8adf233716f75de803d0bf6fc806f60d14d948974a12e240d0\", \"files\": {}}",
-        "dest": "cargo/vendor/graphene-sys-0.19.0",
+        "contents": "{\"package\": \"2f530e0944bccba4b55065e9c69f4975ad691609191ebac16e13ab8e1f27af05\", \"files\": {}}",
+        "dest": "cargo/vendor/graphene-sys-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gsk4/gsk4-0.8.0.crate",
-        "sha256": "0e8ce8dee0fd87a11002214b1204ff18c9272fbd530408f0884a0f9b25dc31de",
-        "dest": "cargo/vendor/gsk4-0.8.0"
+        "url": "https://static.crates.io/crates/gsk4/gsk4-0.8.2.crate",
+        "sha256": "7563884bf6939f4468e5d94654945bdd9afcaf8c3ba4c5dd17b5342b747221be",
+        "dest": "cargo/vendor/gsk4-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0e8ce8dee0fd87a11002214b1204ff18c9272fbd530408f0884a0f9b25dc31de\", \"files\": {}}",
-        "dest": "cargo/vendor/gsk4-0.8.0",
+        "contents": "{\"package\": \"7563884bf6939f4468e5d94654945bdd9afcaf8c3ba4c5dd17b5342b747221be\", \"files\": {}}",
+        "dest": "cargo/vendor/gsk4-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.8.0.crate",
-        "sha256": "2660a652da5b662d43924df19ba40d73f015ed427329ef51d2b1360a4e0dc0e4",
-        "dest": "cargo/vendor/gsk4-sys-0.8.0"
+        "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.8.2.crate",
+        "sha256": "23024bf2636c38bbd1f822f58acc9d1c25b28da896ff0f291a1a232d4272b3dc",
+        "dest": "cargo/vendor/gsk4-sys-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2660a652da5b662d43924df19ba40d73f015ed427329ef51d2b1360a4e0dc0e4\", \"files\": {}}",
-        "dest": "cargo/vendor/gsk4-sys-0.8.0",
+        "contents": "{\"package\": \"23024bf2636c38bbd1f822f58acc9d1c25b28da896ff0f291a1a232d4272b3dc\", \"files\": {}}",
+        "dest": "cargo/vendor/gsk4-sys-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4/gtk4-0.8.0.crate",
-        "sha256": "7d26ffa3ec6316ccaa1df62d3e7f5bae1637c0acbb43f250fabef38319f73c64",
-        "dest": "cargo/vendor/gtk4-0.8.0"
+        "url": "https://static.crates.io/crates/gtk4/gtk4-0.8.2.crate",
+        "sha256": "b04e11319b08af11358ab543105a9e49b0c491faca35e2b8e7e36bfba8b671ab",
+        "dest": "cargo/vendor/gtk4-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7d26ffa3ec6316ccaa1df62d3e7f5bae1637c0acbb43f250fabef38319f73c64\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-0.8.0",
+        "contents": "{\"package\": \"b04e11319b08af11358ab543105a9e49b0c491faca35e2b8e7e36bfba8b671ab\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.8.0.crate",
-        "sha256": "c8b86439e9896f6f3f47c3d8077c5c8205174078760afdabd9098a8e9e937d97",
-        "dest": "cargo/vendor/gtk4-macros-0.8.0"
+        "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.8.2.crate",
+        "sha256": "ec655a7ef88d8ce9592899deb8b2d0fa50bab1e6dd69182deb764e643c522408",
+        "dest": "cargo/vendor/gtk4-macros-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c8b86439e9896f6f3f47c3d8077c5c8205174078760afdabd9098a8e9e937d97\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-macros-0.8.0",
+        "contents": "{\"package\": \"ec655a7ef88d8ce9592899deb8b2d0fa50bab1e6dd69182deb764e643c522408\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-macros-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.8.0.crate",
-        "sha256": "2abc0a6d356d59a3806021829ce6ed3e70bba3509b41a535fedcb09fae13fbc0",
-        "dest": "cargo/vendor/gtk4-sys-0.8.0"
+        "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.8.2.crate",
+        "sha256": "8c8aa86b7f85ea71d66ea88c1d4bae1cfacf51ca4856274565133838d77e57b5",
+        "dest": "cargo/vendor/gtk4-sys-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2abc0a6d356d59a3806021829ce6ed3e70bba3509b41a535fedcb09fae13fbc0\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-sys-0.8.0",
+        "contents": "{\"package\": \"8c8aa86b7f85ea71d66ea88c1d4bae1cfacf51ca4856274565133838d77e57b5\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-sys-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/half/half-2.3.1.crate",
-        "sha256": "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872",
-        "dest": "cargo/vendor/half-2.3.1"
+        "url": "https://static.crates.io/crates/half/half-2.4.1.crate",
+        "sha256": "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888",
+        "dest": "cargo/vendor/half-2.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872\", \"files\": {}}",
-        "dest": "cargo/vendor/half-2.3.1",
+        "contents": "{\"package\": \"6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888\", \"files\": {}}",
+        "dest": "cargo/vendor/half-2.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3265,27 +3174,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.13.2.crate",
-        "sha256": "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e",
-        "dest": "cargo/vendor/hashbrown-0.13.2"
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.5.crate",
+        "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
+        "dest": "cargo/vendor/hashbrown-0.14.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e\", \"files\": {}}",
-        "dest": "cargo/vendor/hashbrown-0.13.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.3.crate",
-        "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604",
-        "dest": "cargo/vendor/hashbrown-0.14.3"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604\", \"files\": {}}",
-        "dest": "cargo/vendor/hashbrown-0.14.3",
+        "contents": "{\"package\": \"e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.14.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3304,14 +3200,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.3.6.crate",
-        "sha256": "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd",
-        "dest": "cargo/vendor/hermit-abi-0.3.6"
+        "url": "https://static.crates.io/crates/heck/heck-0.5.0.crate",
+        "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+        "dest": "cargo/vendor/heck-0.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd\", \"files\": {}}",
-        "dest": "cargo/vendor/hermit-abi-0.3.6",
+        "contents": "{\"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\", \"files\": {}}",
+        "dest": "cargo/vendor/heck-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.3.9.crate",
+        "sha256": "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024",
+        "dest": "cargo/vendor/hermit-abi-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024\", \"files\": {}}",
+        "dest": "cargo/vendor/hermit-abi-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.4.0.crate",
+        "sha256": "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc",
+        "dest": "cargo/vendor/hermit-abi-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc\", \"files\": {}}",
+        "dest": "cargo/vendor/hermit-abi-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3369,131 +3291,131 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-backend-linuxkms/i-slint-backend-linuxkms-1.4.1.crate",
-        "sha256": "7fff24de728432445a94f890093bd852a7c3fd01ae282e40ae0eab6ea629a66d",
-        "dest": "cargo/vendor/i-slint-backend-linuxkms-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-backend-linuxkms/i-slint-backend-linuxkms-1.8.0.crate",
+        "sha256": "ab8f782e541bb2c856e388a63a409215a4f22876e68a5582f00032145fc08f9f",
+        "dest": "cargo/vendor/i-slint-backend-linuxkms-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7fff24de728432445a94f890093bd852a7c3fd01ae282e40ae0eab6ea629a66d\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-backend-linuxkms-1.4.1",
+        "contents": "{\"package\": \"ab8f782e541bb2c856e388a63a409215a4f22876e68a5582f00032145fc08f9f\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-backend-linuxkms-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-backend-selector/i-slint-backend-selector-1.4.1.crate",
-        "sha256": "1953f792a394a7ad26932b4989646719fb126910029006f7cef40ffd189633d0",
-        "dest": "cargo/vendor/i-slint-backend-selector-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-backend-selector/i-slint-backend-selector-1.8.0.crate",
+        "sha256": "350b9375a979856a3655a9905174b055726e85b9c4b6bd315f1d36f6529dbc33",
+        "dest": "cargo/vendor/i-slint-backend-selector-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1953f792a394a7ad26932b4989646719fb126910029006f7cef40ffd189633d0\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-backend-selector-1.4.1",
+        "contents": "{\"package\": \"350b9375a979856a3655a9905174b055726e85b9c4b6bd315f1d36f6529dbc33\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-backend-selector-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-backend-winit/i-slint-backend-winit-1.4.1.crate",
-        "sha256": "138c36c5c9e12f22fe07f280200cedb5d31e07641e40e3b45376fe2112ead303",
-        "dest": "cargo/vendor/i-slint-backend-winit-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-backend-winit/i-slint-backend-winit-1.8.0.crate",
+        "sha256": "4831644094018b8533264d601ab54f585ba6cc834068e8eae77e571d4cc5b70e",
+        "dest": "cargo/vendor/i-slint-backend-winit-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"138c36c5c9e12f22fe07f280200cedb5d31e07641e40e3b45376fe2112ead303\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-backend-winit-1.4.1",
+        "contents": "{\"package\": \"4831644094018b8533264d601ab54f585ba6cc834068e8eae77e571d4cc5b70e\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-backend-winit-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-common/i-slint-common-1.4.1.crate",
-        "sha256": "550e9282fda488b76ce057a728168d1aef947c758f3221b92ae904b167ab008c",
-        "dest": "cargo/vendor/i-slint-common-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-common/i-slint-common-1.8.0.crate",
+        "sha256": "bdd025e9a8c1bb6f2132ab453a0f552408050115552134200a7edea2247cccce",
+        "dest": "cargo/vendor/i-slint-common-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"550e9282fda488b76ce057a728168d1aef947c758f3221b92ae904b167ab008c\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-common-1.4.1",
+        "contents": "{\"package\": \"bdd025e9a8c1bb6f2132ab453a0f552408050115552134200a7edea2247cccce\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-common-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-compiler/i-slint-compiler-1.4.1.crate",
-        "sha256": "25aa2c3525ea761b3e9251f7869e64dce5f483f7ea1a5e04fe7b9a3fb5780dd6",
-        "dest": "cargo/vendor/i-slint-compiler-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-compiler/i-slint-compiler-1.8.0.crate",
+        "sha256": "5c3d2bb25fc20cbd999e3c812cae181206d0280e6e73e7ead2fd4598412d93d8",
+        "dest": "cargo/vendor/i-slint-compiler-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"25aa2c3525ea761b3e9251f7869e64dce5f483f7ea1a5e04fe7b9a3fb5780dd6\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-compiler-1.4.1",
+        "contents": "{\"package\": \"5c3d2bb25fc20cbd999e3c812cae181206d0280e6e73e7ead2fd4598412d93d8\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-compiler-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-core/i-slint-core-1.4.1.crate",
-        "sha256": "4d40990f7ed42c76799edc0e8cae9a8ffcc77569506a94e86eef81626c7387a7",
-        "dest": "cargo/vendor/i-slint-core-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-core/i-slint-core-1.8.0.crate",
+        "sha256": "6d2757683b3377730a67966479a88d6c9f27f7b50b379e3a31c7fbf954e4a661",
+        "dest": "cargo/vendor/i-slint-core-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4d40990f7ed42c76799edc0e8cae9a8ffcc77569506a94e86eef81626c7387a7\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-core-1.4.1",
+        "contents": "{\"package\": \"6d2757683b3377730a67966479a88d6c9f27f7b50b379e3a31c7fbf954e4a661\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-core-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-core-macros/i-slint-core-macros-1.4.1.crate",
-        "sha256": "4f2a4e4c21ed660181abe101b6f141d920e838fec4bc1ff20f7440dc03fb5ad8",
-        "dest": "cargo/vendor/i-slint-core-macros-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-core-macros/i-slint-core-macros-1.8.0.crate",
+        "sha256": "17c4f06e2ccbf6e7381abd64e8716767e97b5fdf15280decf8f08f8d58cde25c",
+        "dest": "cargo/vendor/i-slint-core-macros-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4f2a4e4c21ed660181abe101b6f141d920e838fec4bc1ff20f7440dc03fb5ad8\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-core-macros-1.4.1",
+        "contents": "{\"package\": \"17c4f06e2ccbf6e7381abd64e8716767e97b5fdf15280decf8f08f8d58cde25c\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-core-macros-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-renderer-femtovg/i-slint-renderer-femtovg-1.4.1.crate",
-        "sha256": "337e6ec928bde01baa27d3fdeddd5a33665952aead4d0d9be9818f573a41344c",
-        "dest": "cargo/vendor/i-slint-renderer-femtovg-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-renderer-femtovg/i-slint-renderer-femtovg-1.8.0.crate",
+        "sha256": "9a450bd34e9493cb8694dbe5998346a84f180fae14ad26ae7d8c385fa0c039f4",
+        "dest": "cargo/vendor/i-slint-renderer-femtovg-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"337e6ec928bde01baa27d3fdeddd5a33665952aead4d0d9be9818f573a41344c\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-renderer-femtovg-1.4.1",
+        "contents": "{\"package\": \"9a450bd34e9493cb8694dbe5998346a84f180fae14ad26ae7d8c385fa0c039f4\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-renderer-femtovg-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i-slint-renderer-skia/i-slint-renderer-skia-1.4.1.crate",
-        "sha256": "1189ac65d7e31129407e2cfef4009cdea500040a73d8f87505949f82af0939db",
-        "dest": "cargo/vendor/i-slint-renderer-skia-1.4.1"
+        "url": "https://static.crates.io/crates/i-slint-renderer-skia/i-slint-renderer-skia-1.8.0.crate",
+        "sha256": "51d6e478f22705e017db15416434d5dec7b138b6a1853baacdb489b8b558c1eb",
+        "dest": "cargo/vendor/i-slint-renderer-skia-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1189ac65d7e31129407e2cfef4009cdea500040a73d8f87505949f82af0939db\", \"files\": {}}",
-        "dest": "cargo/vendor/i-slint-renderer-skia-1.4.1",
+        "contents": "{\"package\": \"51d6e478f22705e017db15416434d5dec7b138b6a1853baacdb489b8b558c1eb\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-renderer-skia-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i18n-config/i18n-config-0.4.6.crate",
-        "sha256": "0c9ce3c48cbc21fd5b22b9331f32b5b51f6ad85d969b99e793427332e76e7640",
-        "dest": "cargo/vendor/i18n-config-0.4.6"
+        "url": "https://static.crates.io/crates/i18n-config/i18n-config-0.4.7.crate",
+        "sha256": "8e88074831c0be5b89181b05e6748c4915f77769ecc9a4c372f88b169a8509c9",
+        "dest": "cargo/vendor/i18n-config-0.4.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0c9ce3c48cbc21fd5b22b9331f32b5b51f6ad85d969b99e793427332e76e7640\", \"files\": {}}",
-        "dest": "cargo/vendor/i18n-config-0.4.6",
+        "contents": "{\"package\": \"8e88074831c0be5b89181b05e6748c4915f77769ecc9a4c372f88b169a8509c9\", \"files\": {}}",
+        "dest": "cargo/vendor/i18n-config-0.4.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3538,14 +3460,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.60.crate",
-        "sha256": "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141",
-        "dest": "cargo/vendor/iana-time-zone-0.1.60"
+        "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.61.crate",
+        "sha256": "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220",
+        "dest": "cargo/vendor/iana-time-zone-0.1.61"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141\", \"files\": {}}",
-        "dest": "cargo/vendor/iana-time-zone-0.1.60",
+        "contents": "{\"package\": \"235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220\", \"files\": {}}",
+        "dest": "cargo/vendor/iana-time-zone-0.1.61",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3559,19 +3481,6 @@
         "type": "inline",
         "contents": "{\"package\": \"f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f\", \"files\": {}}",
         "dest": "cargo/vendor/iana-time-zone-haiku-0.1.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icrate/icrate-0.0.4.crate",
-        "sha256": "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319",
-        "dest": "cargo/vendor/icrate-0.0.4"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319\", \"files\": {}}",
-        "dest": "cargo/vendor/icrate-0.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3603,14 +3512,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/image/image-0.24.8.crate",
-        "sha256": "034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23",
-        "dest": "cargo/vendor/image-0.24.8"
+        "url": "https://static.crates.io/crates/image/image-0.24.9.crate",
+        "sha256": "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d",
+        "dest": "cargo/vendor/image-0.24.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23\", \"files\": {}}",
-        "dest": "cargo/vendor/image-0.24.8",
+        "contents": "{\"package\": \"5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d\", \"files\": {}}",
+        "dest": "cargo/vendor/image-0.24.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/image/image-0.25.2.crate",
+        "sha256": "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10",
+        "dest": "cargo/vendor/image-0.25.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10\", \"files\": {}}",
+        "dest": "cargo/vendor/image-0.25.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3681,14 +3603,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/indexmap/indexmap-2.2.3.crate",
-        "sha256": "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177",
-        "dest": "cargo/vendor/indexmap-2.2.3"
+        "url": "https://static.crates.io/crates/indexmap/indexmap-2.5.0.crate",
+        "sha256": "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5",
+        "dest": "cargo/vendor/indexmap-2.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177\", \"files\": {}}",
-        "dest": "cargo/vendor/indexmap-2.2.3",
+        "contents": "{\"package\": \"68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3733,14 +3655,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/input/input-0.8.3.crate",
-        "sha256": "e6e74cd82cedcd66db78742a8337bdc48f188c4d2c12742cbc5cd85113f0b059",
-        "dest": "cargo/vendor/input-0.8.3"
+        "url": "https://static.crates.io/crates/input/input-0.9.1.crate",
+        "sha256": "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9",
+        "dest": "cargo/vendor/input-0.9.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e6e74cd82cedcd66db78742a8337bdc48f188c4d2c12742cbc5cd85113f0b059\", \"files\": {}}",
-        "dest": "cargo/vendor/input-0.8.3",
+        "contents": "{\"package\": \"fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9\", \"files\": {}}",
+        "dest": "cargo/vendor/input-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3759,14 +3681,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/instant/instant-0.1.12.crate",
-        "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
-        "dest": "cargo/vendor/instant-0.1.12"
+        "url": "https://static.crates.io/crates/instant/instant-0.1.13.crate",
+        "sha256": "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222",
+        "dest": "cargo/vendor/instant-0.1.13"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c\", \"files\": {}}",
-        "dest": "cargo/vendor/instant-0.1.12",
+        "contents": "{\"package\": \"e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222\", \"files\": {}}",
+        "dest": "cargo/vendor/instant-0.1.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3785,14 +3707,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/intl-memoizer/intl-memoizer-0.5.1.crate",
-        "sha256": "c310433e4a310918d6ed9243542a6b83ec1183df95dff8f23f87bb88a264a66f",
-        "dest": "cargo/vendor/intl-memoizer-0.5.1"
+        "url": "https://static.crates.io/crates/intl-memoizer/intl-memoizer-0.5.2.crate",
+        "sha256": "fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda",
+        "dest": "cargo/vendor/intl-memoizer-0.5.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c310433e4a310918d6ed9243542a6b83ec1183df95dff8f23f87bb88a264a66f\", \"files\": {}}",
-        "dest": "cargo/vendor/intl-memoizer-0.5.1",
+        "contents": "{\"package\": \"fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda\", \"files\": {}}",
+        "dest": "cargo/vendor/intl-memoizer-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3850,6 +3772,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is_terminal_polyfill/is_terminal_polyfill-1.70.1.crate",
+        "sha256": "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf",
+        "dest": "cargo/vendor/is_terminal_polyfill-1.70.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf\", \"files\": {}}",
+        "dest": "cargo/vendor/is_terminal_polyfill-1.70.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/istring/istring-0.3.4.crate",
         "sha256": "875cc6fb9aecbc1a9bd736f2d18b12e0756b4c80c5e35e28262154abcb077a39",
         "dest": "cargo/vendor/istring-0.3.4"
@@ -3889,14 +3824,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/itoa/itoa-1.0.10.crate",
-        "sha256": "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c",
-        "dest": "cargo/vendor/itoa-1.0.10"
+        "url": "https://static.crates.io/crates/itertools/itertools-0.13.0.crate",
+        "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+        "dest": "cargo/vendor/itertools-0.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c\", \"files\": {}}",
-        "dest": "cargo/vendor/itoa-1.0.10",
+        "contents": "{\"package\": \"413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186\", \"files\": {}}",
+        "dest": "cargo/vendor/itertools-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itoa/itoa-1.0.11.crate",
+        "sha256": "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b",
+        "dest": "cargo/vendor/itoa-1.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b\", \"files\": {}}",
+        "dest": "cargo/vendor/itoa-1.0.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3928,14 +3876,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/jobserver/jobserver-0.1.28.crate",
-        "sha256": "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6",
-        "dest": "cargo/vendor/jobserver-0.1.28"
+        "url": "https://static.crates.io/crates/jobserver/jobserver-0.1.32.crate",
+        "sha256": "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0",
+        "dest": "cargo/vendor/jobserver-0.1.32"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6\", \"files\": {}}",
-        "dest": "cargo/vendor/jobserver-0.1.28",
+        "contents": "{\"package\": \"48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0\", \"files\": {}}",
+        "dest": "cargo/vendor/jobserver-0.1.32",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3954,14 +3902,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.68.crate",
-        "sha256": "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee",
-        "dest": "cargo/vendor/js-sys-0.3.68"
+        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.70.crate",
+        "sha256": "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a",
+        "dest": "cargo/vendor/js-sys-0.3.70"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee\", \"files\": {}}",
-        "dest": "cargo/vendor/js-sys-0.3.68",
+        "contents": "{\"package\": \"1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a\", \"files\": {}}",
+        "dest": "cargo/vendor/js-sys-0.3.70",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3980,14 +3928,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/kurbo/kurbo-0.9.5.crate",
-        "sha256": "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b",
-        "dest": "cargo/vendor/kurbo-0.9.5"
+        "url": "https://static.crates.io/crates/kurbo/kurbo-0.11.1.crate",
+        "sha256": "89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f",
+        "dest": "cargo/vendor/kurbo-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b\", \"files\": {}}",
-        "dest": "cargo/vendor/kurbo-0.9.5",
+        "contents": "{\"package\": \"89234b2cc610a7dd927ebde6b41dd1a5d4214cffaef4cf1fb2195d592f92518f\", \"files\": {}}",
+        "dest": "cargo/vendor/kurbo-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4006,14 +3954,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.4.0.crate",
-        "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
-        "dest": "cargo/vendor/lazy_static-1.4.0"
+        "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.5.0.crate",
+        "sha256": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe",
+        "dest": "cargo/vendor/lazy_static-1.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646\", \"files\": {}}",
-        "dest": "cargo/vendor/lazy_static-1.4.0",
+        "contents": "{\"package\": \"bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe\", \"files\": {}}",
+        "dest": "cargo/vendor/lazy_static-1.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4045,40 +3993,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libc/libc-0.2.153.crate",
-        "sha256": "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd",
-        "dest": "cargo/vendor/libc-0.2.153"
+        "url": "https://static.crates.io/crates/libc/libc-0.2.159.crate",
+        "sha256": "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5",
+        "dest": "cargo/vendor/libc-0.2.159"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd\", \"files\": {}}",
-        "dest": "cargo/vendor/libc-0.2.153",
+        "contents": "{\"package\": \"561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.159",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libflate/libflate-2.0.0.crate",
-        "sha256": "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf",
-        "dest": "cargo/vendor/libflate-2.0.0"
+        "url": "https://static.crates.io/crates/libflate/libflate-2.1.0.crate",
+        "sha256": "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e",
+        "dest": "cargo/vendor/libflate-2.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf\", \"files\": {}}",
-        "dest": "cargo/vendor/libflate-2.0.0",
+        "contents": "{\"package\": \"45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e\", \"files\": {}}",
+        "dest": "cargo/vendor/libflate-2.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libflate_lz77/libflate_lz77-2.0.0.crate",
-        "sha256": "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524",
-        "dest": "cargo/vendor/libflate_lz77-2.0.0"
+        "url": "https://static.crates.io/crates/libflate_lz77/libflate_lz77-2.1.0.crate",
+        "sha256": "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d",
+        "dest": "cargo/vendor/libflate_lz77-2.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524\", \"files\": {}}",
-        "dest": "cargo/vendor/libflate_lz77-2.0.0",
+        "contents": "{\"package\": \"e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d\", \"files\": {}}",
+        "dest": "cargo/vendor/libflate_lz77-2.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4123,14 +4071,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libloading/libloading-0.8.1.crate",
-        "sha256": "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161",
-        "dest": "cargo/vendor/libloading-0.8.1"
+        "url": "https://static.crates.io/crates/libloading/libloading-0.8.5.crate",
+        "sha256": "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4",
+        "dest": "cargo/vendor/libloading-0.8.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161\", \"files\": {}}",
-        "dest": "cargo/vendor/libloading-0.8.1",
+        "contents": "{\"package\": \"4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.8.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4175,19 +4123,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libredox/libredox-0.0.1.crate",
-        "sha256": "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8",
-        "dest": "cargo/vendor/libredox-0.0.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8\", \"files\": {}}",
-        "dest": "cargo/vendor/libredox-0.0.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libredox/libredox-0.0.2.crate",
         "sha256": "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607",
         "dest": "cargo/vendor/libredox-0.0.2"
@@ -4196,6 +4131,19 @@
         "type": "inline",
         "contents": "{\"package\": \"3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607\", \"files\": {}}",
         "dest": "cargo/vendor/libredox-0.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libredox/libredox-0.1.3.crate",
+        "sha256": "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d",
+        "dest": "cargo/vendor/libredox-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d\", \"files\": {}}",
+        "dest": "cargo/vendor/libredox-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4240,40 +4188,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.3.8.crate",
-        "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
-        "dest": "cargo/vendor/linux-raw-sys-0.3.8"
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.14.crate",
+        "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89",
+        "dest": "cargo/vendor/linux-raw-sys-0.4.14"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519\", \"files\": {}}",
-        "dest": "cargo/vendor/linux-raw-sys-0.3.8",
+        "contents": "{\"package\": \"78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.4.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.13.crate",
-        "sha256": "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.13"
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.6.5.crate",
+        "sha256": "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7",
+        "dest": "cargo/vendor/linux-raw-sys-0.6.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c\", \"files\": {}}",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.13",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.6.4.crate",
-        "sha256": "f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4",
-        "dest": "cargo/vendor/linux-raw-sys-0.6.4"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4\", \"files\": {}}",
-        "dest": "cargo/vendor/linux-raw-sys-0.6.4",
+        "contents": "{\"package\": \"2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.6.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4292,14 +4227,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.11.crate",
-        "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
-        "dest": "cargo/vendor/lock_api-0.4.11"
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.12.crate",
+        "sha256": "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17",
+        "dest": "cargo/vendor/lock_api-0.4.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45\", \"files\": {}}",
-        "dest": "cargo/vendor/lock_api-0.4.11",
+        "contents": "{\"package\": \"07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17\", \"files\": {}}",
+        "dest": "cargo/vendor/lock_api-0.4.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4331,14 +4266,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/log/log-0.4.20.crate",
-        "sha256": "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f",
-        "dest": "cargo/vendor/log-0.4.20"
+        "url": "https://static.crates.io/crates/log/log-0.4.22.crate",
+        "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+        "dest": "cargo/vendor/log-0.4.22"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f\", \"files\": {}}",
-        "dest": "cargo/vendor/log-0.4.20",
+        "contents": "{\"package\": \"a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.4.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4357,14 +4292,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lru/lru-0.12.2.crate",
-        "sha256": "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22",
-        "dest": "cargo/vendor/lru-0.12.2"
+        "url": "https://static.crates.io/crates/lru/lru-0.12.4.crate",
+        "sha256": "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904",
+        "dest": "cargo/vendor/lru-0.12.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22\", \"files\": {}}",
-        "dest": "cargo/vendor/lru-0.12.2",
+        "contents": "{\"package\": \"37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904\", \"files\": {}}",
+        "dest": "cargo/vendor/lru-0.12.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4383,14 +4318,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lyon_extra/lyon_extra-1.0.1.crate",
-        "sha256": "b9ce2ae38f2480094ec1f0d5df51a75581fa84f0e8f32a0edb1d264630c99f3b",
-        "dest": "cargo/vendor/lyon_extra-1.0.1"
+        "url": "https://static.crates.io/crates/lyon_extra/lyon_extra-1.0.2.crate",
+        "sha256": "8c4a243ce61e7e5f3ae6c72a88d8fb081b6c69f13500c15e99cfd1159a833b20",
+        "dest": "cargo/vendor/lyon_extra-1.0.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b9ce2ae38f2480094ec1f0d5df51a75581fa84f0e8f32a0edb1d264630c99f3b\", \"files\": {}}",
-        "dest": "cargo/vendor/lyon_extra-1.0.1",
+        "contents": "{\"package\": \"8c4a243ce61e7e5f3ae6c72a88d8fb081b6c69f13500c15e99cfd1159a833b20\", \"files\": {}}",
+        "dest": "cargo/vendor/lyon_extra-1.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4409,14 +4344,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lyon_path/lyon_path-1.0.4.crate",
-        "sha256": "ca507745ba7ccbc76e5c44e7b63b1a29d2b0d6126f375806a5bbaf657c7d6c45",
-        "dest": "cargo/vendor/lyon_path-1.0.4"
+        "url": "https://static.crates.io/crates/lyon_path/lyon_path-1.0.5.crate",
+        "sha256": "9c08a606c7a59638d6c6aa18ac91a06aa9fb5f765a7efb27e6a4da58700740d7",
+        "dest": "cargo/vendor/lyon_path-1.0.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ca507745ba7ccbc76e5c44e7b63b1a29d2b0d6126f375806a5bbaf657c7d6c45\", \"files\": {}}",
-        "dest": "cargo/vendor/lyon_path-1.0.4",
+        "contents": "{\"package\": \"9c08a606c7a59638d6c6aa18ac91a06aa9fb5f765a7efb27e6a4da58700740d7\", \"files\": {}}",
+        "dest": "cargo/vendor/lyon_path-1.0.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4461,66 +4396,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memchr/memchr-2.7.1.crate",
-        "sha256": "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149",
-        "dest": "cargo/vendor/memchr-2.7.1"
+        "url": "https://static.crates.io/crates/memchr/memchr-2.7.4.crate",
+        "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+        "dest": "cargo/vendor/memchr-2.7.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149\", \"files\": {}}",
-        "dest": "cargo/vendor/memchr-2.7.1",
+        "contents": "{\"package\": \"78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3\", \"files\": {}}",
+        "dest": "cargo/vendor/memchr-2.7.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memmap2/memmap2-0.8.0.crate",
-        "sha256": "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed",
-        "dest": "cargo/vendor/memmap2-0.8.0"
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.9.5.crate",
+        "sha256": "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f",
+        "dest": "cargo/vendor/memmap2-0.9.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed\", \"files\": {}}",
-        "dest": "cargo/vendor/memmap2-0.8.0",
+        "contents": "{\"package\": \"fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.9.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memmap2/memmap2-0.9.4.crate",
-        "sha256": "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322",
-        "dest": "cargo/vendor/memmap2-0.9.4"
+        "url": "https://static.crates.io/crates/memoffset/memoffset-0.9.1.crate",
+        "sha256": "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a",
+        "dest": "cargo/vendor/memoffset-0.9.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322\", \"files\": {}}",
-        "dest": "cargo/vendor/memmap2-0.9.4",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memoffset/memoffset-0.7.1.crate",
-        "sha256": "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4",
-        "dest": "cargo/vendor/memoffset-0.7.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4\", \"files\": {}}",
-        "dest": "cargo/vendor/memoffset-0.7.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memoffset/memoffset-0.9.0.crate",
-        "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
-        "dest": "cargo/vendor/memoffset-0.9.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c\", \"files\": {}}",
-        "dest": "cargo/vendor/memoffset-0.9.0",
+        "contents": "{\"package\": \"488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a\", \"files\": {}}",
+        "dest": "cargo/vendor/memoffset-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4552,14 +4461,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/mime_guess/mime_guess-2.0.4.crate",
-        "sha256": "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef",
-        "dest": "cargo/vendor/mime_guess-2.0.4"
+        "url": "https://static.crates.io/crates/mime_guess/mime_guess-2.0.5.crate",
+        "sha256": "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e",
+        "dest": "cargo/vendor/mime_guess-2.0.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef\", \"files\": {}}",
-        "dest": "cargo/vendor/mime_guess-2.0.4",
+        "contents": "{\"package\": \"f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e\", \"files\": {}}",
+        "dest": "cargo/vendor/mime_guess-2.0.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4578,14 +4487,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.7.2.crate",
-        "sha256": "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7",
-        "dest": "cargo/vendor/miniz_oxide-0.7.2"
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.7.4.crate",
+        "sha256": "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08",
+        "dest": "cargo/vendor/miniz_oxide-0.7.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7\", \"files\": {}}",
-        "dest": "cargo/vendor/miniz_oxide-0.7.2",
+        "contents": "{\"package\": \"b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.7.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.8.0.crate",
+        "sha256": "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1",
+        "dest": "cargo/vendor/miniz_oxide-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4604,14 +4526,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ndk/ndk-0.8.0.crate",
-        "sha256": "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7",
-        "dest": "cargo/vendor/ndk-0.8.0"
+        "url": "https://static.crates.io/crates/ndk/ndk-0.9.0.crate",
+        "sha256": "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4",
+        "dest": "cargo/vendor/ndk-0.9.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7\", \"files\": {}}",
-        "dest": "cargo/vendor/ndk-0.8.0",
+        "contents": "{\"package\": \"c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4630,40 +4552,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ndk-sys/ndk-sys-0.5.0+25.2.9519653.crate",
-        "sha256": "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691",
-        "dest": "cargo/vendor/ndk-sys-0.5.0+25.2.9519653"
+        "url": "https://static.crates.io/crates/ndk-sys/ndk-sys-0.6.0+11769913.crate",
+        "sha256": "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873",
+        "dest": "cargo/vendor/ndk-sys-0.6.0+11769913"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691\", \"files\": {}}",
-        "dest": "cargo/vendor/ndk-sys-0.5.0+25.2.9519653",
+        "contents": "{\"package\": \"ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-sys-0.6.0+11769913",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/nix/nix-0.26.4.crate",
-        "sha256": "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b",
-        "dest": "cargo/vendor/nix-0.26.4"
+        "url": "https://static.crates.io/crates/nix/nix-0.29.0.crate",
+        "sha256": "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46",
+        "dest": "cargo/vendor/nix-0.29.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b\", \"files\": {}}",
-        "dest": "cargo/vendor/nix-0.26.4",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/nix/nix-0.27.1.crate",
-        "sha256": "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053",
-        "dest": "cargo/vendor/nix-0.27.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053\", \"files\": {}}",
-        "dest": "cargo/vendor/nix-0.27.1",
+        "contents": "{\"package\": \"71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46\", \"files\": {}}",
+        "dest": "cargo/vendor/nix-0.29.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4708,14 +4617,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.5.crate",
-        "sha256": "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6",
-        "dest": "cargo/vendor/num-complex-0.4.5"
+        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.6.crate",
+        "sha256": "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495",
+        "dest": "cargo/vendor/num-complex-0.4.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6\", \"files\": {}}",
-        "dest": "cargo/vendor/num-complex-0.4.5",
+        "contents": "{\"package\": \"73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495\", \"files\": {}}",
+        "dest": "cargo/vendor/num-complex-0.4.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4747,40 +4656,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.18.crate",
-        "sha256": "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a",
-        "dest": "cargo/vendor/num-traits-0.2.18"
+        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.19.crate",
+        "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
+        "dest": "cargo/vendor/num-traits-0.2.19"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a\", \"files\": {}}",
-        "dest": "cargo/vendor/num-traits-0.2.18",
+        "contents": "{\"package\": \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\", \"files\": {}}",
+        "dest": "cargo/vendor/num-traits-0.2.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num_enum/num_enum-0.7.2.crate",
-        "sha256": "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845",
-        "dest": "cargo/vendor/num_enum-0.7.2"
+        "url": "https://static.crates.io/crates/num_enum/num_enum-0.7.3.crate",
+        "sha256": "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179",
+        "dest": "cargo/vendor/num_enum-0.7.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845\", \"files\": {}}",
-        "dest": "cargo/vendor/num_enum-0.7.2",
+        "contents": "{\"package\": \"4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum-0.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.7.2.crate",
-        "sha256": "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b",
-        "dest": "cargo/vendor/num_enum_derive-0.7.2"
+        "url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.7.3.crate",
+        "sha256": "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56",
+        "dest": "cargo/vendor/num_enum_derive-0.7.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b\", \"files\": {}}",
-        "dest": "cargo/vendor/num_enum_derive-0.7.2",
+        "contents": "{\"package\": \"af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum_derive-0.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4838,40 +4747,222 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc-sys/objc-sys-0.3.2.crate",
-        "sha256": "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459",
-        "dest": "cargo/vendor/objc-sys-0.3.2"
+        "url": "https://static.crates.io/crates/objc-sys/objc-sys-0.3.5.crate",
+        "sha256": "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310",
+        "dest": "cargo/vendor/objc-sys-0.3.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459\", \"files\": {}}",
-        "dest": "cargo/vendor/objc-sys-0.3.2",
+        "contents": "{\"package\": \"cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310\", \"files\": {}}",
+        "dest": "cargo/vendor/objc-sys-0.3.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc2/objc2-0.4.1.crate",
-        "sha256": "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d",
-        "dest": "cargo/vendor/objc2-0.4.1"
+        "url": "https://static.crates.io/crates/objc2/objc2-0.5.2.crate",
+        "sha256": "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804",
+        "dest": "cargo/vendor/objc2-0.5.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d\", \"files\": {}}",
-        "dest": "cargo/vendor/objc2-0.4.1",
+        "contents": "{\"package\": \"46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc2-encode/objc2-encode-3.0.0.crate",
-        "sha256": "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666",
-        "dest": "cargo/vendor/objc2-encode-3.0.0"
+        "url": "https://static.crates.io/crates/objc2-app-kit/objc2-app-kit-0.2.2.crate",
+        "sha256": "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff",
+        "dest": "cargo/vendor/objc2-app-kit-0.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666\", \"files\": {}}",
-        "dest": "cargo/vendor/objc2-encode-3.0.0",
+        "contents": "{\"package\": \"e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-app-kit-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-cloud-kit/objc2-cloud-kit-0.2.2.crate",
+        "sha256": "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009",
+        "dest": "cargo/vendor/objc2-cloud-kit-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-cloud-kit-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-contacts/objc2-contacts-0.2.2.crate",
+        "sha256": "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889",
+        "dest": "cargo/vendor/objc2-contacts-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-contacts-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-data/objc2-core-data-0.2.2.crate",
+        "sha256": "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef",
+        "dest": "cargo/vendor/objc2-core-data-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-data-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-image/objc2-core-image-0.2.2.crate",
+        "sha256": "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80",
+        "dest": "cargo/vendor/objc2-core-image-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-image-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-location/objc2-core-location-0.2.2.crate",
+        "sha256": "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781",
+        "dest": "cargo/vendor/objc2-core-location-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-location-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-encode/objc2-encode-4.0.3.crate",
+        "sha256": "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8",
+        "dest": "cargo/vendor/objc2-encode-4.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-encode-4.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-foundation/objc2-foundation-0.2.2.crate",
+        "sha256": "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8",
+        "dest": "cargo/vendor/objc2-foundation-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-foundation-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-link-presentation/objc2-link-presentation-0.2.2.crate",
+        "sha256": "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398",
+        "dest": "cargo/vendor/objc2-link-presentation-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-link-presentation-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-metal/objc2-metal-0.2.2.crate",
+        "sha256": "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6",
+        "dest": "cargo/vendor/objc2-metal-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-metal-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-quartz-core/objc2-quartz-core-0.2.2.crate",
+        "sha256": "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a",
+        "dest": "cargo/vendor/objc2-quartz-core-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-quartz-core-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-symbols/objc2-symbols-0.2.2.crate",
+        "sha256": "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc",
+        "dest": "cargo/vendor/objc2-symbols-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-symbols-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-ui-kit/objc2-ui-kit-0.2.2.crate",
+        "sha256": "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f",
+        "dest": "cargo/vendor/objc2-ui-kit-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-ui-kit-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-uniform-type-identifiers/objc2-uniform-type-identifiers-0.2.2.crate",
+        "sha256": "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe",
+        "dest": "cargo/vendor/objc2-uniform-type-identifiers-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-uniform-type-identifiers-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-user-notifications/objc2-user-notifications-0.2.2.crate",
+        "sha256": "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3",
+        "dest": "cargo/vendor/objc2-user-notifications-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-user-notifications-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4903,40 +4994,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ogg_pager/ogg_pager-0.6.0.crate",
-        "sha256": "c949d63b387b25c332f6e39d1762dd4b405008289dd7681f02c258b1294653ca",
-        "dest": "cargo/vendor/ogg_pager-0.6.0"
+        "url": "https://static.crates.io/crates/ogg_pager/ogg_pager-0.6.1.crate",
+        "sha256": "87b0bef808533c5890ab77279538212efdbbbd9aa4ef1ccdfcfbf77a42f7e6fa",
+        "dest": "cargo/vendor/ogg_pager-0.6.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c949d63b387b25c332f6e39d1762dd4b405008289dd7681f02c258b1294653ca\", \"files\": {}}",
-        "dest": "cargo/vendor/ogg_pager-0.6.0",
+        "contents": "{\"package\": \"87b0bef808533c5890ab77279538212efdbbbd9aa4ef1ccdfcfbf77a42f7e6fa\", \"files\": {}}",
+        "dest": "cargo/vendor/ogg_pager-0.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/once_cell/once_cell-1.19.0.crate",
-        "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
-        "dest": "cargo/vendor/once_cell-1.19.0"
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.20.1.crate",
+        "sha256": "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1",
+        "dest": "cargo/vendor/once_cell-1.20.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92\", \"files\": {}}",
-        "dest": "cargo/vendor/once_cell-1.19.0",
+        "contents": "{\"package\": \"82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.20.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/open/open-5.0.1.crate",
-        "sha256": "90878fb664448b54c4e592455ad02831e23a3f7e157374a8b95654731aac7349",
-        "dest": "cargo/vendor/open-5.0.1"
+        "url": "https://static.crates.io/crates/open/open-5.3.0.crate",
+        "sha256": "61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3",
+        "dest": "cargo/vendor/open-5.3.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"90878fb664448b54c4e592455ad02831e23a3f7e157374a8b95654731aac7349\", \"files\": {}}",
-        "dest": "cargo/vendor/open-5.0.1",
+        "contents": "{\"package\": \"61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3\", \"files\": {}}",
+        "dest": "cargo/vendor/open-5.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4968,14 +5059,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/os_info/os_info-3.7.0.crate",
-        "sha256": "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e",
-        "dest": "cargo/vendor/os_info-3.7.0"
+        "url": "https://static.crates.io/crates/os_info/os_info-3.8.2.crate",
+        "sha256": "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092",
+        "dest": "cargo/vendor/os_info-3.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e\", \"files\": {}}",
-        "dest": "cargo/vendor/os_info-3.7.0",
+        "contents": "{\"package\": \"ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092\", \"files\": {}}",
+        "dest": "cargo/vendor/os_info-3.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4994,79 +5085,79 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.20.0.crate",
-        "sha256": "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7",
-        "dest": "cargo/vendor/owned_ttf_parser-0.20.0"
+        "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.24.0.crate",
+        "sha256": "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90",
+        "dest": "cargo/vendor/owned_ttf_parser-0.24.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7\", \"files\": {}}",
-        "dest": "cargo/vendor/owned_ttf_parser-0.20.0",
+        "contents": "{\"package\": \"490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90\", \"files\": {}}",
+        "dest": "cargo/vendor/owned_ttf_parser-0.24.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pango/pango-0.19.2.crate",
-        "sha256": "7809e8af4df8d024a066106b72ca6bc7253a484ae3867041a96103ef8a13188d",
-        "dest": "cargo/vendor/pango-0.19.2"
+        "url": "https://static.crates.io/crates/pango/pango-0.19.8.crate",
+        "sha256": "3f0d328648058085cfd6897c9ae4272884098a926f3a833cd50c8c73e6eccecd",
+        "dest": "cargo/vendor/pango-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7809e8af4df8d024a066106b72ca6bc7253a484ae3867041a96103ef8a13188d\", \"files\": {}}",
-        "dest": "cargo/vendor/pango-0.19.2",
+        "contents": "{\"package\": \"3f0d328648058085cfd6897c9ae4272884098a926f3a833cd50c8c73e6eccecd\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.19.0.crate",
-        "sha256": "f52ef6a881c19fbfe3b1484df5cad411acaaba29dbec843941c3110d19f340ea",
-        "dest": "cargo/vendor/pango-sys-0.19.0"
+        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.19.8.crate",
+        "sha256": "ff03da4fa086c0b244d4a4587d3e20622a3ecdb21daea9edf66597224c634ba0",
+        "dest": "cargo/vendor/pango-sys-0.19.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f52ef6a881c19fbfe3b1484df5cad411acaaba29dbec843941c3110d19f340ea\", \"files\": {}}",
-        "dest": "cargo/vendor/pango-sys-0.19.0",
+        "contents": "{\"package\": \"ff03da4fa086c0b244d4a4587d3e20622a3ecdb21daea9edf66597224c634ba0\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-sys-0.19.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/parking/parking-2.2.0.crate",
-        "sha256": "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae",
-        "dest": "cargo/vendor/parking-2.2.0"
+        "url": "https://static.crates.io/crates/parking/parking-2.2.1.crate",
+        "sha256": "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba",
+        "dest": "cargo/vendor/parking-2.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae\", \"files\": {}}",
-        "dest": "cargo/vendor/parking-2.2.0",
+        "contents": "{\"package\": \"f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba\", \"files\": {}}",
+        "dest": "cargo/vendor/parking-2.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.12.1.crate",
-        "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
-        "dest": "cargo/vendor/parking_lot-0.12.1"
+        "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.12.3.crate",
+        "sha256": "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27",
+        "dest": "cargo/vendor/parking_lot-0.12.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f\", \"files\": {}}",
-        "dest": "cargo/vendor/parking_lot-0.12.1",
+        "contents": "{\"package\": \"f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot-0.12.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.9.crate",
-        "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
-        "dest": "cargo/vendor/parking_lot_core-0.9.9"
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.10.crate",
+        "sha256": "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8",
+        "dest": "cargo/vendor/parking_lot_core-0.9.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e\", \"files\": {}}",
-        "dest": "cargo/vendor/parking_lot_core-0.9.9",
+        "contents": "{\"package\": \"1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot_core-0.9.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5085,14 +5176,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/paste/paste-1.0.14.crate",
-        "sha256": "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c",
-        "dest": "cargo/vendor/paste-1.0.14"
+        "url": "https://static.crates.io/crates/paste/paste-1.0.15.crate",
+        "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
+        "dest": "cargo/vendor/paste-1.0.15"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c\", \"files\": {}}",
-        "dest": "cargo/vendor/paste-1.0.14",
+        "contents": "{\"package\": \"57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a\", \"files\": {}}",
+        "dest": "cargo/vendor/paste-1.0.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5176,40 +5267,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pin-project/pin-project-1.1.4.crate",
-        "sha256": "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0",
-        "dest": "cargo/vendor/pin-project-1.1.4"
+        "url": "https://static.crates.io/crates/pin-project/pin-project-1.1.5.crate",
+        "sha256": "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3",
+        "dest": "cargo/vendor/pin-project-1.1.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0\", \"files\": {}}",
-        "dest": "cargo/vendor/pin-project-1.1.4",
+        "contents": "{\"package\": \"b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-1.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.1.4.crate",
-        "sha256": "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690",
-        "dest": "cargo/vendor/pin-project-internal-1.1.4"
+        "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.1.5.crate",
+        "sha256": "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965",
+        "dest": "cargo/vendor/pin-project-internal-1.1.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690\", \"files\": {}}",
-        "dest": "cargo/vendor/pin-project-internal-1.1.4",
+        "contents": "{\"package\": \"2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-internal-1.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.13.crate",
-        "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58",
-        "dest": "cargo/vendor/pin-project-lite-0.2.13"
+        "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.14.crate",
+        "sha256": "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02",
+        "dest": "cargo/vendor/pin-project-lite-0.2.14"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58\", \"files\": {}}",
-        "dest": "cargo/vendor/pin-project-lite-0.2.13",
+        "contents": "{\"package\": \"bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-lite-0.2.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5241,66 +5332,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/piper/piper-0.2.1.crate",
-        "sha256": "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4",
-        "dest": "cargo/vendor/piper-0.2.1"
+        "url": "https://static.crates.io/crates/piper/piper-0.2.4.crate",
+        "sha256": "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066",
+        "dest": "cargo/vendor/piper-0.2.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4\", \"files\": {}}",
-        "dest": "cargo/vendor/piper-0.2.1",
+        "contents": "{\"package\": \"96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066\", \"files\": {}}",
+        "dest": "cargo/vendor/piper-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.30.crate",
-        "sha256": "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec",
-        "dest": "cargo/vendor/pkg-config-0.3.30"
+        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.31.crate",
+        "sha256": "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2",
+        "dest": "cargo/vendor/pkg-config-0.3.31"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec\", \"files\": {}}",
-        "dest": "cargo/vendor/pkg-config-0.3.30",
+        "contents": "{\"package\": \"953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2\", \"files\": {}}",
+        "dest": "cargo/vendor/pkg-config-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/png/png-0.17.12.crate",
-        "sha256": "78c2378060fb13acff3ba0325b83442c1d2c44fbb76df481160ddc1687cce160",
-        "dest": "cargo/vendor/png-0.17.12"
+        "url": "https://static.crates.io/crates/png/png-0.17.14.crate",
+        "sha256": "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0",
+        "dest": "cargo/vendor/png-0.17.14"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"78c2378060fb13acff3ba0325b83442c1d2c44fbb76df481160ddc1687cce160\", \"files\": {}}",
-        "dest": "cargo/vendor/png-0.17.12",
+        "contents": "{\"package\": \"52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.17.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/polling/polling-2.8.0.crate",
-        "sha256": "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce",
-        "dest": "cargo/vendor/polling-2.8.0"
+        "url": "https://static.crates.io/crates/polling/polling-3.7.3.crate",
+        "sha256": "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511",
+        "dest": "cargo/vendor/polling-3.7.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce\", \"files\": {}}",
-        "dest": "cargo/vendor/polling-2.8.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/polling/polling-3.5.0.crate",
-        "sha256": "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9",
-        "dest": "cargo/vendor/polling-3.5.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9\", \"files\": {}}",
-        "dest": "cargo/vendor/polling-3.5.0",
+        "contents": "{\"package\": \"cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511\", \"files\": {}}",
+        "dest": "cargo/vendor/polling-3.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5319,14 +5397,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/portable-atomic/portable-atomic-1.6.0.crate",
-        "sha256": "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0",
-        "dest": "cargo/vendor/portable-atomic-1.6.0"
+        "url": "https://static.crates.io/crates/portable-atomic/portable-atomic-1.9.0.crate",
+        "sha256": "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2",
+        "dest": "cargo/vendor/portable-atomic-1.9.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0\", \"files\": {}}",
-        "dest": "cargo/vendor/portable-atomic-1.6.0",
+        "contents": "{\"package\": \"cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2\", \"files\": {}}",
+        "dest": "cargo/vendor/portable-atomic-1.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5345,66 +5423,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.17.crate",
-        "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
-        "dest": "cargo/vendor/ppv-lite86-0.2.17"
+        "url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.20.crate",
+        "sha256": "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04",
+        "dest": "cargo/vendor/ppv-lite86-0.2.20"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de\", \"files\": {}}",
-        "dest": "cargo/vendor/ppv-lite86-0.2.17",
+        "contents": "{\"package\": \"77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04\", \"files\": {}}",
+        "dest": "cargo/vendor/ppv-lite86-0.2.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.16.crate",
-        "sha256": "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5",
-        "dest": "cargo/vendor/prettyplease-0.2.16"
+        "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.22.crate",
+        "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+        "dest": "cargo/vendor/prettyplease-0.2.22"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5\", \"files\": {}}",
-        "dest": "cargo/vendor/prettyplease-0.2.16",
+        "contents": "{\"package\": \"479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba\", \"files\": {}}",
+        "dest": "cargo/vendor/prettyplease-0.2.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/primal-check/primal-check-0.3.3.crate",
-        "sha256": "9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0",
-        "dest": "cargo/vendor/primal-check-0.3.3"
+        "url": "https://static.crates.io/crates/primal-check/primal-check-0.3.4.crate",
+        "sha256": "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08",
+        "dest": "cargo/vendor/primal-check-0.3.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0\", \"files\": {}}",
-        "dest": "cargo/vendor/primal-check-0.3.3",
+        "contents": "{\"package\": \"dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08\", \"files\": {}}",
+        "dest": "cargo/vendor/primal-check-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.3.1.crate",
-        "sha256": "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919",
-        "dest": "cargo/vendor/proc-macro-crate-1.3.1"
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.2.0.crate",
+        "sha256": "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b",
+        "dest": "cargo/vendor/proc-macro-crate-3.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro-crate-1.3.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.1.0.crate",
-        "sha256": "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284",
-        "dest": "cargo/vendor/proc-macro-crate-3.1.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro-crate-3.1.0",
+        "contents": "{\"package\": \"8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-3.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5436,14 +5501,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.78.crate",
-        "sha256": "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae",
-        "dest": "cargo/vendor/proc-macro2-1.0.78"
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.86.crate",
+        "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+        "dest": "cargo/vendor/proc-macro2-1.0.86"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro2-1.0.78",
+        "contents": "{\"package\": \"5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.86",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5462,27 +5527,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.31.0.crate",
-        "sha256": "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33",
-        "dest": "cargo/vendor/quick-xml-0.31.0"
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.36.2.crate",
+        "sha256": "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe",
+        "dest": "cargo/vendor/quick-xml-0.36.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33\", \"files\": {}}",
-        "dest": "cargo/vendor/quick-xml-0.31.0",
+        "contents": "{\"package\": \"f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-xml-0.36.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quote/quote-1.0.35.crate",
-        "sha256": "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef",
-        "dest": "cargo/vendor/quote-1.0.35"
+        "url": "https://static.crates.io/crates/quote/quote-1.0.37.crate",
+        "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+        "dest": "cargo/vendor/quote-1.0.37"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef\", \"files\": {}}",
-        "dest": "cargo/vendor/quote-1.0.35",
+        "contents": "{\"package\": \"b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.37",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5540,6 +5605,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.6.2.crate",
+        "sha256": "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539",
+        "dest": "cargo/vendor/raw-window-handle-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-window-handle-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/raw-window-metal/raw-window-metal-1.0.0.crate",
+        "sha256": "b2000e45d7daa9b6d946e88dfa1d7ae330424a81918a6545741821c989eb80a9",
+        "dest": "cargo/vendor/raw-window-metal-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b2000e45d7daa9b6d946e88dfa1d7ae330424a81918a6545741821c989eb80a9\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-window-metal-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rawloader/rawloader-0.37.1.crate",
         "sha256": "4d8c6f168c492ffd326537b3aa5a8d5fe07f0d8a3970c5957f286bcd13f888aa",
         "dest": "cargo/vendor/rawloader-0.37.1"
@@ -5553,14 +5644,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rayon/rayon-1.8.1.crate",
-        "sha256": "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051",
-        "dest": "cargo/vendor/rayon-1.8.1"
+        "url": "https://static.crates.io/crates/rayon/rayon-1.10.0.crate",
+        "sha256": "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa",
+        "dest": "cargo/vendor/rayon-1.10.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051\", \"files\": {}}",
-        "dest": "cargo/vendor/rayon-1.8.1",
+        "contents": "{\"package\": \"b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-1.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5579,27 +5670,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/realfft/realfft-3.3.0.crate",
-        "sha256": "953d9f7e5cdd80963547b456251296efc2626ed4e3cbf36c869d9564e0220571",
-        "dest": "cargo/vendor/realfft-3.3.0"
+        "url": "https://static.crates.io/crates/realfft/realfft-3.4.0.crate",
+        "sha256": "390252372b7f2aac8360fc5e72eba10136b166d6faeed97e6d0c8324eb99b2b1",
+        "dest": "cargo/vendor/realfft-3.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"953d9f7e5cdd80963547b456251296efc2626ed4e3cbf36c869d9564e0220571\", \"files\": {}}",
-        "dest": "cargo/vendor/realfft-3.3.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.3.5.crate",
-        "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
-        "dest": "cargo/vendor/redox_syscall-0.3.5"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29\", \"files\": {}}",
-        "dest": "cargo/vendor/redox_syscall-0.3.5",
+        "contents": "{\"package\": \"390252372b7f2aac8360fc5e72eba10136b166d6faeed97e6d0c8324eb99b2b1\", \"files\": {}}",
+        "dest": "cargo/vendor/realfft-3.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5618,27 +5696,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.4.crate",
-        "sha256": "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4",
-        "dest": "cargo/vendor/redox_users-0.4.4"
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.5.7.crate",
+        "sha256": "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f",
+        "dest": "cargo/vendor/redox_syscall-0.5.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4\", \"files\": {}}",
-        "dest": "cargo/vendor/redox_users-0.4.4",
+        "contents": "{\"package\": \"9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.5.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex/regex-1.10.3.crate",
-        "sha256": "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15",
-        "dest": "cargo/vendor/regex-1.10.3"
+        "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.6.crate",
+        "sha256": "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43",
+        "dest": "cargo/vendor/redox_users-0.4.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-1.10.3",
+        "contents": "{\"package\": \"ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_users-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex/regex-1.11.0.crate",
+        "sha256": "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8",
+        "dest": "cargo/vendor/regex-1.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-1.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5657,14 +5748,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.5.crate",
-        "sha256": "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd",
-        "dest": "cargo/vendor/regex-automata-0.4.5"
+        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.8.crate",
+        "sha256": "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3",
+        "dest": "cargo/vendor/regex-automata-0.4.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-automata-0.4.5",
+        "contents": "{\"package\": \"368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-automata-0.4.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5683,53 +5774,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.2.crate",
-        "sha256": "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f",
-        "dest": "cargo/vendor/regex-syntax-0.8.2"
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.5.crate",
+        "sha256": "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c",
+        "dest": "cargo/vendor/regex-syntax-0.8.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-syntax-0.8.2",
+        "contents": "{\"package\": \"2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-syntax-0.8.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/resvg/resvg-0.38.0.crate",
-        "sha256": "5c34501046959e06470ba62a2dc7f31c15f94ac250d842a45f9e012f4ee40c1e",
-        "dest": "cargo/vendor/resvg-0.38.0"
+        "url": "https://static.crates.io/crates/resvg/resvg-0.42.0.crate",
+        "sha256": "944d052815156ac8fa77eaac055220e95ba0b01fa8887108ca710c03805d9051",
+        "dest": "cargo/vendor/resvg-0.42.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5c34501046959e06470ba62a2dc7f31c15f94ac250d842a45f9e012f4ee40c1e\", \"files\": {}}",
-        "dest": "cargo/vendor/resvg-0.38.0",
+        "contents": "{\"package\": \"944d052815156ac8fa77eaac055220e95ba0b01fa8887108ca710c03805d9051\", \"files\": {}}",
+        "dest": "cargo/vendor/resvg-0.42.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rfd/rfd-0.13.0.crate",
-        "sha256": "c0d8ab342bcc5436e04d3a4c1e09e17d74958bfaddf8d5fad6f85607df0f994f",
-        "dest": "cargo/vendor/rfd-0.13.0"
+        "url": "https://static.crates.io/crates/rfd/rfd-0.14.1.crate",
+        "sha256": "25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251",
+        "dest": "cargo/vendor/rfd-0.14.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c0d8ab342bcc5436e04d3a4c1e09e17d74958bfaddf8d5fad6f85607df0f994f\", \"files\": {}}",
-        "dest": "cargo/vendor/rfd-0.13.0",
+        "contents": "{\"package\": \"25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251\", \"files\": {}}",
+        "dest": "cargo/vendor/rfd-0.14.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rgb/rgb-0.8.37.crate",
-        "sha256": "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8",
-        "dest": "cargo/vendor/rgb-0.8.37"
+        "url": "https://static.crates.io/crates/rgb/rgb-0.8.50.crate",
+        "sha256": "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a",
+        "dest": "cargo/vendor/rgb-0.8.50"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8\", \"files\": {}}",
-        "dest": "cargo/vendor/rgb-0.8.37",
+        "contents": "{\"package\": \"57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a\", \"files\": {}}",
+        "dest": "cargo/vendor/rgb-0.8.50",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5748,27 +5839,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rowan/rowan-0.15.15.crate",
-        "sha256": "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49",
-        "dest": "cargo/vendor/rowan-0.15.15"
+        "url": "https://static.crates.io/crates/rowan/rowan-0.15.16.crate",
+        "sha256": "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d",
+        "dest": "cargo/vendor/rowan-0.15.16"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49\", \"files\": {}}",
-        "dest": "cargo/vendor/rowan-0.15.15",
+        "contents": "{\"package\": \"0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d\", \"files\": {}}",
+        "dest": "cargo/vendor/rowan-0.15.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/roxmltree/roxmltree-0.19.0.crate",
-        "sha256": "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f",
-        "dest": "cargo/vendor/roxmltree-0.19.0"
+        "url": "https://static.crates.io/crates/roxmltree/roxmltree-0.20.0.crate",
+        "sha256": "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97",
+        "dest": "cargo/vendor/roxmltree-0.20.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f\", \"files\": {}}",
-        "dest": "cargo/vendor/roxmltree-0.19.0",
+        "contents": "{\"package\": \"6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97\", \"files\": {}}",
+        "dest": "cargo/vendor/roxmltree-0.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5787,40 +5878,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rust-embed/rust-embed-8.2.0.crate",
-        "sha256": "a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f",
-        "dest": "cargo/vendor/rust-embed-8.2.0"
+        "url": "https://static.crates.io/crates/rust-embed/rust-embed-8.5.0.crate",
+        "sha256": "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0",
+        "dest": "cargo/vendor/rust-embed-8.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f\", \"files\": {}}",
-        "dest": "cargo/vendor/rust-embed-8.2.0",
+        "contents": "{\"package\": \"fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0\", \"files\": {}}",
+        "dest": "cargo/vendor/rust-embed-8.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rust-embed-impl/rust-embed-impl-8.2.0.crate",
-        "sha256": "6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16",
-        "dest": "cargo/vendor/rust-embed-impl-8.2.0"
+        "url": "https://static.crates.io/crates/rust-embed-impl/rust-embed-impl-8.5.0.crate",
+        "sha256": "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478",
+        "dest": "cargo/vendor/rust-embed-impl-8.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16\", \"files\": {}}",
-        "dest": "cargo/vendor/rust-embed-impl-8.2.0",
+        "contents": "{\"package\": \"6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478\", \"files\": {}}",
+        "dest": "cargo/vendor/rust-embed-impl-8.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rust-embed-utils/rust-embed-utils-8.2.0.crate",
-        "sha256": "8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665",
-        "dest": "cargo/vendor/rust-embed-utils-8.2.0"
+        "url": "https://static.crates.io/crates/rust-embed-utils/rust-embed-utils-8.5.0.crate",
+        "sha256": "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d",
+        "dest": "cargo/vendor/rust-embed-utils-8.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665\", \"files\": {}}",
-        "dest": "cargo/vendor/rust-embed-utils-8.2.0",
+        "contents": "{\"package\": \"2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d\", \"files\": {}}",
+        "dest": "cargo/vendor/rust-embed-utils-8.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5839,14 +5930,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.0.crate",
-        "sha256": "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366",
-        "dest": "cargo/vendor/rustc_version-0.4.0"
+        "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.1.crate",
+        "sha256": "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
+        "dest": "cargo/vendor/rustc_version-0.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366\", \"files\": {}}",
-        "dest": "cargo/vendor/rustc_version-0.4.0",
+        "contents": "{\"package\": \"cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92\", \"files\": {}}",
+        "dest": "cargo/vendor/rustc_version-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5904,40 +5995,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustix/rustix-0.37.27.crate",
-        "sha256": "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2",
-        "dest": "cargo/vendor/rustix-0.37.27"
+        "url": "https://static.crates.io/crates/rustix/rustix-0.38.37.crate",
+        "sha256": "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811",
+        "dest": "cargo/vendor/rustix-0.38.37"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2\", \"files\": {}}",
-        "dest": "cargo/vendor/rustix-0.37.27",
+        "contents": "{\"package\": \"8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-0.38.37",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustix/rustix-0.38.31.crate",
-        "sha256": "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949",
-        "dest": "cargo/vendor/rustix-0.38.31"
+        "url": "https://static.crates.io/crates/rustversion/rustversion-1.0.17.crate",
+        "sha256": "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6",
+        "dest": "cargo/vendor/rustversion-1.0.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949\", \"files\": {}}",
-        "dest": "cargo/vendor/rustix-0.38.31",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustversion/rustversion-1.0.14.crate",
-        "sha256": "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4",
-        "dest": "cargo/vendor/rustversion-1.0.14"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4\", \"files\": {}}",
-        "dest": "cargo/vendor/rustversion-1.0.14",
+        "contents": "{\"package\": \"955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6\", \"files\": {}}",
+        "dest": "cargo/vendor/rustversion-1.0.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5956,40 +6034,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustybuzz/rustybuzz-0.11.0.crate",
-        "sha256": "2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa",
-        "dest": "cargo/vendor/rustybuzz-0.11.0"
+        "url": "https://static.crates.io/crates/rustybuzz/rustybuzz-0.14.1.crate",
+        "sha256": "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c",
+        "dest": "cargo/vendor/rustybuzz-0.14.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa\", \"files\": {}}",
-        "dest": "cargo/vendor/rustybuzz-0.11.0",
+        "contents": "{\"package\": \"cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c\", \"files\": {}}",
+        "dest": "cargo/vendor/rustybuzz-0.14.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustybuzz/rustybuzz-0.12.1.crate",
-        "sha256": "f0ae5692c5beaad6a9e22830deeed7874eae8a4e3ba4076fb48e12c56856222c",
-        "dest": "cargo/vendor/rustybuzz-0.12.1"
+        "url": "https://static.crates.io/crates/ryu/ryu-1.0.18.crate",
+        "sha256": "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f",
+        "dest": "cargo/vendor/ryu-1.0.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f0ae5692c5beaad6a9e22830deeed7874eae8a4e3ba4076fb48e12c56856222c\", \"files\": {}}",
-        "dest": "cargo/vendor/rustybuzz-0.12.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ryu/ryu-1.0.16.crate",
-        "sha256": "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c",
-        "dest": "cargo/vendor/ryu-1.0.16"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c\", \"files\": {}}",
-        "dest": "cargo/vendor/ryu-1.0.16",
+        "contents": "{\"package\": \"f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f\", \"files\": {}}",
+        "dest": "cargo/vendor/ryu-1.0.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6021,14 +6086,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/scoped-tls-hkt/scoped-tls-hkt-0.1.4.crate",
-        "sha256": "3ddc765d3410d9f6c6ca071bf0b67f6b01e3ec4595dc3892f02677e75819dddc",
-        "dest": "cargo/vendor/scoped-tls-hkt-0.1.4"
+        "url": "https://static.crates.io/crates/scoped-tls-hkt/scoped-tls-hkt-0.1.5.crate",
+        "sha256": "e9603871ffe5df3ac39cb624790c296dbd47a400d202f56bf3e414045099524d",
+        "dest": "cargo/vendor/scoped-tls-hkt-0.1.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3ddc765d3410d9f6c6ca071bf0b67f6b01e3ec4595dc3892f02677e75819dddc\", \"files\": {}}",
-        "dest": "cargo/vendor/scoped-tls-hkt-0.1.4",
+        "contents": "{\"package\": \"e9603871ffe5df3ac39cb624790c296dbd47a400d202f56bf3e414045099524d\", \"files\": {}}",
+        "dest": "cargo/vendor/scoped-tls-hkt-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6047,14 +6112,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/sctk-adwaita/sctk-adwaita-0.8.1.crate",
-        "sha256": "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550",
-        "dest": "cargo/vendor/sctk-adwaita-0.8.1"
+        "url": "https://static.crates.io/crates/sctk-adwaita/sctk-adwaita-0.10.1.crate",
+        "sha256": "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec",
+        "dest": "cargo/vendor/sctk-adwaita-0.10.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550\", \"files\": {}}",
-        "dest": "cargo/vendor/sctk-adwaita-0.8.1",
+        "contents": "{\"package\": \"b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec\", \"files\": {}}",
+        "dest": "cargo/vendor/sctk-adwaita-0.10.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6073,92 +6138,92 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/self_cell/self_cell-1.0.3.crate",
-        "sha256": "58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba",
-        "dest": "cargo/vendor/self_cell-1.0.3"
+        "url": "https://static.crates.io/crates/self_cell/self_cell-1.0.4.crate",
+        "sha256": "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a",
+        "dest": "cargo/vendor/self_cell-1.0.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba\", \"files\": {}}",
-        "dest": "cargo/vendor/self_cell-1.0.3",
+        "contents": "{\"package\": \"d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a\", \"files\": {}}",
+        "dest": "cargo/vendor/self_cell-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/semver/semver-1.0.21.crate",
-        "sha256": "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0",
-        "dest": "cargo/vendor/semver-1.0.21"
+        "url": "https://static.crates.io/crates/semver/semver-1.0.23.crate",
+        "sha256": "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b",
+        "dest": "cargo/vendor/semver-1.0.23"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0\", \"files\": {}}",
-        "dest": "cargo/vendor/semver-1.0.21",
+        "contents": "{\"package\": \"61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b\", \"files\": {}}",
+        "dest": "cargo/vendor/semver-1.0.23",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde/serde-1.0.196.crate",
-        "sha256": "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32",
-        "dest": "cargo/vendor/serde-1.0.196"
+        "url": "https://static.crates.io/crates/serde/serde-1.0.210.crate",
+        "sha256": "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a",
+        "dest": "cargo/vendor/serde-1.0.210"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32\", \"files\": {}}",
-        "dest": "cargo/vendor/serde-1.0.196",
+        "contents": "{\"package\": \"c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-1.0.210",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.196.crate",
-        "sha256": "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67",
-        "dest": "cargo/vendor/serde_derive-1.0.196"
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.210.crate",
+        "sha256": "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f",
+        "dest": "cargo/vendor/serde_derive-1.0.210"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_derive-1.0.196",
+        "contents": "{\"package\": \"243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive-1.0.210",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.113.crate",
-        "sha256": "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79",
-        "dest": "cargo/vendor/serde_json-1.0.113"
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.128.crate",
+        "sha256": "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8",
+        "dest": "cargo/vendor/serde_json-1.0.128"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_json-1.0.113",
+        "contents": "{\"package\": \"6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.128",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_repr/serde_repr-0.1.18.crate",
-        "sha256": "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb",
-        "dest": "cargo/vendor/serde_repr-0.1.18"
+        "url": "https://static.crates.io/crates/serde_repr/serde_repr-0.1.19.crate",
+        "sha256": "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9",
+        "dest": "cargo/vendor/serde_repr-0.1.19"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_repr-0.1.18",
+        "contents": "{\"package\": \"6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_repr-0.1.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.5.crate",
-        "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1",
-        "dest": "cargo/vendor/serde_spanned-0.6.5"
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.8.crate",
+        "sha256": "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1",
+        "dest": "cargo/vendor/serde_spanned-0.6.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_spanned-0.6.5",
+        "contents": "{\"package\": \"87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-0.6.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6229,14 +6294,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.1.crate",
-        "sha256": "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1",
-        "dest": "cargo/vendor/signal-hook-registry-1.4.1"
+        "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.2.crate",
+        "sha256": "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1\", \"files\": {}}",
-        "dest": "cargo/vendor/signal-hook-registry-1.4.1",
+        "contents": "{\"package\": \"a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6268,40 +6333,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/siphasher/siphasher-0.3.11.crate",
-        "sha256": "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d",
-        "dest": "cargo/vendor/siphasher-0.3.11"
+        "url": "https://static.crates.io/crates/siphasher/siphasher-1.0.1.crate",
+        "sha256": "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d",
+        "dest": "cargo/vendor/siphasher-1.0.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d\", \"files\": {}}",
-        "dest": "cargo/vendor/siphasher-0.3.11",
+        "contents": "{\"package\": \"56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d\", \"files\": {}}",
+        "dest": "cargo/vendor/siphasher-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/skia-bindings/skia-bindings-0.70.0.crate",
-        "sha256": "4bc61a106126a429bb4775ce5fbe23b2bcaa74d1a9c484997f4700de31480b44",
-        "dest": "cargo/vendor/skia-bindings-0.70.0"
+        "url": "https://static.crates.io/crates/skia-bindings/skia-bindings-0.78.2.crate",
+        "sha256": "29880a81b088de322e9c5306236c70761a61b5fa4df3c15c93bad3ce890ce34c",
+        "dest": "cargo/vendor/skia-bindings-0.78.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4bc61a106126a429bb4775ce5fbe23b2bcaa74d1a9c484997f4700de31480b44\", \"files\": {}}",
-        "dest": "cargo/vendor/skia-bindings-0.70.0",
+        "contents": "{\"package\": \"29880a81b088de322e9c5306236c70761a61b5fa4df3c15c93bad3ce890ce34c\", \"files\": {}}",
+        "dest": "cargo/vendor/skia-bindings-0.78.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/skia-safe/skia-safe-0.70.0.crate",
-        "sha256": "3201eba92bca1f83864f5c3a48309bcfee7e0590bebd7826e7ab0a49aa24a750",
-        "dest": "cargo/vendor/skia-safe-0.70.0"
+        "url": "https://static.crates.io/crates/skia-safe/skia-safe-0.78.2.crate",
+        "sha256": "4f15700ac678c06649077495acbba07e7ae01e5ca46b7dc18213f2c3477ada71",
+        "dest": "cargo/vendor/skia-safe-0.78.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3201eba92bca1f83864f5c3a48309bcfee7e0590bebd7826e7ab0a49aa24a750\", \"files\": {}}",
-        "dest": "cargo/vendor/skia-safe-0.70.0",
+        "contents": "{\"package\": \"4f15700ac678c06649077495acbba07e7ae01e5ca46b7dc18213f2c3477ada71\", \"files\": {}}",
+        "dest": "cargo/vendor/skia-safe-0.78.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6320,40 +6385,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/slint/slint-1.4.1.crate",
-        "sha256": "7d51a972e5c6f22793f9b334eeb537121337fbf66ed73e978475fca031fd367a",
-        "dest": "cargo/vendor/slint-1.4.1"
+        "url": "https://static.crates.io/crates/slint/slint-1.8.0.crate",
+        "sha256": "c4ec667df21d0bf4a5eb49735ab476c809a625ba2fa9a59a2405bc9edf0977ce",
+        "dest": "cargo/vendor/slint-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7d51a972e5c6f22793f9b334eeb537121337fbf66ed73e978475fca031fd367a\", \"files\": {}}",
-        "dest": "cargo/vendor/slint-1.4.1",
+        "contents": "{\"package\": \"c4ec667df21d0bf4a5eb49735ab476c809a625ba2fa9a59a2405bc9edf0977ce\", \"files\": {}}",
+        "dest": "cargo/vendor/slint-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/slint-build/slint-build-1.4.1.crate",
-        "sha256": "ebf98969a520e19ec675435b8c21b883d4a06489947e137bbd30859b50ad0c36",
-        "dest": "cargo/vendor/slint-build-1.4.1"
+        "url": "https://static.crates.io/crates/slint-build/slint-build-1.8.0.crate",
+        "sha256": "ec068281021ccd3a69dbe36a0caf207d88aa5b50945ced9000f17a5d2b139003",
+        "dest": "cargo/vendor/slint-build-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ebf98969a520e19ec675435b8c21b883d4a06489947e137bbd30859b50ad0c36\", \"files\": {}}",
-        "dest": "cargo/vendor/slint-build-1.4.1",
+        "contents": "{\"package\": \"ec068281021ccd3a69dbe36a0caf207d88aa5b50945ced9000f17a5d2b139003\", \"files\": {}}",
+        "dest": "cargo/vendor/slint-build-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/slint-macros/slint-macros-1.4.1.crate",
-        "sha256": "564b2a25cc34007aa9cd73630394efa972b956fee86538caa5d09808b3ba0c05",
-        "dest": "cargo/vendor/slint-macros-1.4.1"
+        "url": "https://static.crates.io/crates/slint-macros/slint-macros-1.8.0.crate",
+        "sha256": "9f79eb3465efc8fb2f1939fd7473cbdfc75aa2d4eef3d2b3964b60595e357a2f",
+        "dest": "cargo/vendor/slint-macros-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"564b2a25cc34007aa9cd73630394efa972b956fee86538caa5d09808b3ba0c05\", \"files\": {}}",
-        "dest": "cargo/vendor/slint-macros-1.4.1",
+        "contents": "{\"package\": \"9f79eb3465efc8fb2f1939fd7473cbdfc75aa2d4eef3d2b3964b60595e357a2f\", \"files\": {}}",
+        "dest": "cargo/vendor/slint-macros-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6372,53 +6437,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/smallvec/smallvec-1.13.1.crate",
-        "sha256": "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7",
-        "dest": "cargo/vendor/smallvec-1.13.1"
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.13.2.crate",
+        "sha256": "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67",
+        "dest": "cargo/vendor/smallvec-1.13.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7\", \"files\": {}}",
-        "dest": "cargo/vendor/smallvec-1.13.1",
+        "contents": "{\"package\": \"3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-1.13.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/smithay-client-toolkit/smithay-client-toolkit-0.18.1.crate",
-        "sha256": "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a",
-        "dest": "cargo/vendor/smithay-client-toolkit-0.18.1"
+        "url": "https://static.crates.io/crates/smithay-client-toolkit/smithay-client-toolkit-0.19.2.crate",
+        "sha256": "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016",
+        "dest": "cargo/vendor/smithay-client-toolkit-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a\", \"files\": {}}",
-        "dest": "cargo/vendor/smithay-client-toolkit-0.18.1",
+        "contents": "{\"package\": \"3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016\", \"files\": {}}",
+        "dest": "cargo/vendor/smithay-client-toolkit-0.19.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/smithay-clipboard/smithay-clipboard-0.7.0.crate",
-        "sha256": "0bb62b280ce5a5cba847669933a0948d00904cf83845c944eae96a4738cea1a6",
-        "dest": "cargo/vendor/smithay-clipboard-0.7.0"
+        "url": "https://static.crates.io/crates/smithay-clipboard/smithay-clipboard-0.7.2.crate",
+        "sha256": "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846",
+        "dest": "cargo/vendor/smithay-clipboard-0.7.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0bb62b280ce5a5cba847669933a0948d00904cf83845c944eae96a4738cea1a6\", \"files\": {}}",
-        "dest": "cargo/vendor/smithay-clipboard-0.7.0",
+        "contents": "{\"package\": \"cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846\", \"files\": {}}",
+        "dest": "cargo/vendor/smithay-clipboard-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/smol_str/smol_str-0.2.1.crate",
-        "sha256": "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49",
-        "dest": "cargo/vendor/smol_str-0.2.1"
+        "url": "https://static.crates.io/crates/smol_str/smol_str-0.2.2.crate",
+        "sha256": "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead",
+        "dest": "cargo/vendor/smol_str-0.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49\", \"files\": {}}",
-        "dest": "cargo/vendor/smol_str-0.2.1",
+        "contents": "{\"package\": \"dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead\", \"files\": {}}",
+        "dest": "cargo/vendor/smol_str-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smol_str/smol_str-0.3.1.crate",
+        "sha256": "66eaf762c5af19db3108300515c8aa7a50efc90ff745f4c62288052ebf9fdd25",
+        "dest": "cargo/vendor/smol_str-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"66eaf762c5af19db3108300515c8aa7a50efc90ff745f4c62288052ebf9fdd25\", \"files\": {}}",
+        "dest": "cargo/vendor/smol_str-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6450,27 +6528,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/socket2/socket2-0.4.10.crate",
-        "sha256": "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d",
-        "dest": "cargo/vendor/socket2-0.4.10"
+        "url": "https://static.crates.io/crates/softbuffer/softbuffer-0.4.6.crate",
+        "sha256": "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08",
+        "dest": "cargo/vendor/softbuffer-0.4.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d\", \"files\": {}}",
-        "dest": "cargo/vendor/socket2-0.4.10",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/softbuffer/softbuffer-0.3.4.crate",
-        "sha256": "f266ce2aa23eaaaa4e758ed44495d505d00fb79f359d46f6c1900cb053123b62",
-        "dest": "cargo/vendor/softbuffer-0.3.4"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"f266ce2aa23eaaaa4e758ed44495d505d00fb79f359d46f6c1900cb053123b62\", \"files\": {}}",
-        "dest": "cargo/vendor/softbuffer-0.3.4",
+        "contents": "{\"package\": \"18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08\", \"files\": {}}",
+        "dest": "cargo/vendor/softbuffer-0.4.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6567,14 +6632,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/stringprep/stringprep-0.1.4.crate",
-        "sha256": "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6",
-        "dest": "cargo/vendor/stringprep-0.1.4"
+        "url": "https://static.crates.io/crates/stringprep/stringprep-0.1.5.crate",
+        "sha256": "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1",
+        "dest": "cargo/vendor/stringprep-0.1.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6\", \"files\": {}}",
-        "dest": "cargo/vendor/stringprep-0.1.4",
+        "contents": "{\"package\": \"7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1\", \"files\": {}}",
+        "dest": "cargo/vendor/stringprep-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6593,261 +6658,274 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/strsim/strsim-0.11.0.crate",
-        "sha256": "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01",
-        "dest": "cargo/vendor/strsim-0.11.0"
+        "url": "https://static.crates.io/crates/strsim/strsim-0.11.1.crate",
+        "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
+        "dest": "cargo/vendor/strsim-0.11.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01\", \"files\": {}}",
-        "dest": "cargo/vendor/strsim-0.11.0",
+        "contents": "{\"package\": \"7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f\", \"files\": {}}",
+        "dest": "cargo/vendor/strsim-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/strum/strum-0.26.1.crate",
-        "sha256": "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f",
-        "dest": "cargo/vendor/strum-0.26.1"
+        "url": "https://static.crates.io/crates/strum/strum-0.26.3.crate",
+        "sha256": "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06",
+        "dest": "cargo/vendor/strum-0.26.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f\", \"files\": {}}",
-        "dest": "cargo/vendor/strum-0.26.1",
+        "contents": "{\"package\": \"8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06\", \"files\": {}}",
+        "dest": "cargo/vendor/strum-0.26.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/strum_macros/strum_macros-0.26.1.crate",
-        "sha256": "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18",
-        "dest": "cargo/vendor/strum_macros-0.26.1"
+        "url": "https://static.crates.io/crates/strum_macros/strum_macros-0.26.4.crate",
+        "sha256": "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be",
+        "dest": "cargo/vendor/strum_macros-0.26.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18\", \"files\": {}}",
-        "dest": "cargo/vendor/strum_macros-0.26.1",
+        "contents": "{\"package\": \"4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be\", \"files\": {}}",
+        "dest": "cargo/vendor/strum_macros-0.26.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/subtle/subtle-2.5.0.crate",
-        "sha256": "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc",
-        "dest": "cargo/vendor/subtle-2.5.0"
+        "url": "https://static.crates.io/crates/subtle/subtle-2.6.1.crate",
+        "sha256": "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292",
+        "dest": "cargo/vendor/subtle-2.6.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc\", \"files\": {}}",
-        "dest": "cargo/vendor/subtle-2.5.0",
+        "contents": "{\"package\": \"13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292\", \"files\": {}}",
+        "dest": "cargo/vendor/subtle-2.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/svgtypes/svgtypes-0.13.0.crate",
-        "sha256": "6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70",
-        "dest": "cargo/vendor/svgtypes-0.13.0"
+        "url": "https://static.crates.io/crates/svgtypes/svgtypes-0.15.2.crate",
+        "sha256": "794de53cc48eaabeed0ab6a3404a65f40b3e38c067e4435883a65d2aa4ca000e",
+        "dest": "cargo/vendor/svgtypes-0.15.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70\", \"files\": {}}",
-        "dest": "cargo/vendor/svgtypes-0.13.0",
+        "contents": "{\"package\": \"794de53cc48eaabeed0ab6a3404a65f40b3e38c067e4435883a65d2aa4ca000e\", \"files\": {}}",
+        "dest": "cargo/vendor/svgtypes-0.15.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia/symphonia-0.5.3.crate",
-        "sha256": "62e48dba70095f265fdb269b99619b95d04c89e619538138383e63310b14d941",
-        "dest": "cargo/vendor/symphonia-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia/symphonia-0.5.4.crate",
+        "sha256": "815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9",
+        "dest": "cargo/vendor/symphonia-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"62e48dba70095f265fdb269b99619b95d04c89e619538138383e63310b14d941\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-0.5.3",
+        "contents": "{\"package\": \"815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-bundle-flac/symphonia-bundle-flac-0.5.3.crate",
-        "sha256": "7f23b0482a7cb18fcdf9981ab0b78df800ef0080187d294650023c462439058d",
-        "dest": "cargo/vendor/symphonia-bundle-flac-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-bundle-flac/symphonia-bundle-flac-0.5.4.crate",
+        "sha256": "72e34f34298a7308d4397a6c7fbf5b84c5d491231ce3dd379707ba673ab3bd97",
+        "dest": "cargo/vendor/symphonia-bundle-flac-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7f23b0482a7cb18fcdf9981ab0b78df800ef0080187d294650023c462439058d\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-bundle-flac-0.5.3",
+        "contents": "{\"package\": \"72e34f34298a7308d4397a6c7fbf5b84c5d491231ce3dd379707ba673ab3bd97\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-bundle-flac-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-bundle-mp3/symphonia-bundle-mp3-0.5.3.crate",
-        "sha256": "0f31d7fece546f1e6973011a9eceae948133bbd18fd3d52f6073b1e38ae6368a",
-        "dest": "cargo/vendor/symphonia-bundle-mp3-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-bundle-mp3/symphonia-bundle-mp3-0.5.4.crate",
+        "sha256": "c01c2aae70f0f1fb096b6f0ff112a930b1fb3626178fba3ae68b09dce71706d4",
+        "dest": "cargo/vendor/symphonia-bundle-mp3-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0f31d7fece546f1e6973011a9eceae948133bbd18fd3d52f6073b1e38ae6368a\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-bundle-mp3-0.5.3",
+        "contents": "{\"package\": \"c01c2aae70f0f1fb096b6f0ff112a930b1fb3626178fba3ae68b09dce71706d4\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-bundle-mp3-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-codec-aac/symphonia-codec-aac-0.5.3.crate",
-        "sha256": "68bdd75b25ce4b84b12a4bd20bfea2460c2dbd7fc1d227ef5533504d3168109d",
-        "dest": "cargo/vendor/symphonia-codec-aac-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-codec-aac/symphonia-codec-aac-0.5.4.crate",
+        "sha256": "cdbf25b545ad0d3ee3e891ea643ad115aff4ca92f6aec472086b957a58522f70",
+        "dest": "cargo/vendor/symphonia-codec-aac-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"68bdd75b25ce4b84b12a4bd20bfea2460c2dbd7fc1d227ef5533504d3168109d\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-codec-aac-0.5.3",
+        "contents": "{\"package\": \"cdbf25b545ad0d3ee3e891ea643ad115aff4ca92f6aec472086b957a58522f70\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-codec-aac-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-codec-adpcm/symphonia-codec-adpcm-0.5.3.crate",
-        "sha256": "870e7dc1865d818c7b6318879d060553a73a3b2a3b8443dff90910f10ac41150",
-        "dest": "cargo/vendor/symphonia-codec-adpcm-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-codec-adpcm/symphonia-codec-adpcm-0.5.4.crate",
+        "sha256": "c94e1feac3327cd616e973d5be69ad36b3945f16b06f19c6773fc3ac0b426a0f",
+        "dest": "cargo/vendor/symphonia-codec-adpcm-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"870e7dc1865d818c7b6318879d060553a73a3b2a3b8443dff90910f10ac41150\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-codec-adpcm-0.5.3",
+        "contents": "{\"package\": \"c94e1feac3327cd616e973d5be69ad36b3945f16b06f19c6773fc3ac0b426a0f\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-codec-adpcm-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-codec-alac/symphonia-codec-alac-0.5.3.crate",
-        "sha256": "3a27e8763d1c9eff666faf903e73a99d4de2f7a93fca4e3c214c1d68432903b9",
-        "dest": "cargo/vendor/symphonia-codec-alac-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-codec-alac/symphonia-codec-alac-0.5.4.crate",
+        "sha256": "2d8a6666649a08412906476a8b0efd9b9733e241180189e9f92b09c08d0e38f3",
+        "dest": "cargo/vendor/symphonia-codec-alac-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3a27e8763d1c9eff666faf903e73a99d4de2f7a93fca4e3c214c1d68432903b9\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-codec-alac-0.5.3",
+        "contents": "{\"package\": \"2d8a6666649a08412906476a8b0efd9b9733e241180189e9f92b09c08d0e38f3\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-codec-alac-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-codec-pcm/symphonia-codec-pcm-0.5.3.crate",
-        "sha256": "47f1fbd220a06a641c8ce2ddad10f5ef6ee5cc0c54d9044d25d43b0d3119deaa",
-        "dest": "cargo/vendor/symphonia-codec-pcm-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-codec-pcm/symphonia-codec-pcm-0.5.4.crate",
+        "sha256": "f395a67057c2ebc5e84d7bb1be71cce1a7ba99f64e0f0f0e303a03f79116f89b",
+        "dest": "cargo/vendor/symphonia-codec-pcm-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"47f1fbd220a06a641c8ce2ddad10f5ef6ee5cc0c54d9044d25d43b0d3119deaa\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-codec-pcm-0.5.3",
+        "contents": "{\"package\": \"f395a67057c2ebc5e84d7bb1be71cce1a7ba99f64e0f0f0e303a03f79116f89b\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-codec-pcm-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-codec-vorbis/symphonia-codec-vorbis-0.5.3.crate",
-        "sha256": "3953397e3506aa01350c4205817e4f95b58d476877a42f0458d07b665749e203",
-        "dest": "cargo/vendor/symphonia-codec-vorbis-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-codec-vorbis/symphonia-codec-vorbis-0.5.4.crate",
+        "sha256": "5a98765fb46a0a6732b007f7e2870c2129b6f78d87db7987e6533c8f164a9f30",
+        "dest": "cargo/vendor/symphonia-codec-vorbis-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3953397e3506aa01350c4205817e4f95b58d476877a42f0458d07b665749e203\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-codec-vorbis-0.5.3",
+        "contents": "{\"package\": \"5a98765fb46a0a6732b007f7e2870c2129b6f78d87db7987e6533c8f164a9f30\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-codec-vorbis-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-core/symphonia-core-0.5.3.crate",
-        "sha256": "f7c73eb88fee79705268cc7b742c7bc93a7b76e092ab751d0833866970754142",
-        "dest": "cargo/vendor/symphonia-core-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-core/symphonia-core-0.5.4.crate",
+        "sha256": "798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3",
+        "dest": "cargo/vendor/symphonia-core-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f7c73eb88fee79705268cc7b742c7bc93a7b76e092ab751d0833866970754142\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-core-0.5.3",
+        "contents": "{\"package\": \"798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-core-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-format-isomp4/symphonia-format-isomp4-0.5.3.crate",
-        "sha256": "ffdf14bae5cf352032416bc64151e5d6242d29d33cbf3238513b44d4427a1efb",
-        "dest": "cargo/vendor/symphonia-format-isomp4-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-format-caf/symphonia-format-caf-0.5.4.crate",
+        "sha256": "e43c99c696a388295a29fe71b133079f5d8b18041cf734c5459c35ad9097af50",
+        "dest": "cargo/vendor/symphonia-format-caf-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ffdf14bae5cf352032416bc64151e5d6242d29d33cbf3238513b44d4427a1efb\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-format-isomp4-0.5.3",
+        "contents": "{\"package\": \"e43c99c696a388295a29fe71b133079f5d8b18041cf734c5459c35ad9097af50\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-format-caf-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-format-mkv/symphonia-format-mkv-0.5.3.crate",
-        "sha256": "f5c61dfc851ad25d4043d8c231d8617e8f7cd02a6cc0edad21ade21848d58895",
-        "dest": "cargo/vendor/symphonia-format-mkv-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-format-isomp4/symphonia-format-isomp4-0.5.4.crate",
+        "sha256": "abfdf178d697e50ce1e5d9b982ba1b94c47218e03ec35022d9f0e071a16dc844",
+        "dest": "cargo/vendor/symphonia-format-isomp4-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f5c61dfc851ad25d4043d8c231d8617e8f7cd02a6cc0edad21ade21848d58895\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-format-mkv-0.5.3",
+        "contents": "{\"package\": \"abfdf178d697e50ce1e5d9b982ba1b94c47218e03ec35022d9f0e071a16dc844\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-format-isomp4-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-format-ogg/symphonia-format-ogg-0.5.3.crate",
-        "sha256": "9bf1a00ccd11452d44048a0368828040f778ae650418dbd9d8765b7ee2574c8d",
-        "dest": "cargo/vendor/symphonia-format-ogg-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-format-mkv/symphonia-format-mkv-0.5.4.crate",
+        "sha256": "1bb43471a100f7882dc9937395bd5ebee8329298e766250b15b3875652fe3d6f",
+        "dest": "cargo/vendor/symphonia-format-mkv-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9bf1a00ccd11452d44048a0368828040f778ae650418dbd9d8765b7ee2574c8d\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-format-ogg-0.5.3",
+        "contents": "{\"package\": \"1bb43471a100f7882dc9937395bd5ebee8329298e766250b15b3875652fe3d6f\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-format-mkv-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-format-wav/symphonia-format-wav-0.5.3.crate",
-        "sha256": "da76614728fa27c003bdcdfbac51396bd8fcbf94c95fe8e62f1d2bac58ef03a4",
-        "dest": "cargo/vendor/symphonia-format-wav-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-format-ogg/symphonia-format-ogg-0.5.4.crate",
+        "sha256": "ada3505789516bcf00fc1157c67729eded428b455c27ca370e41f4d785bfa931",
+        "dest": "cargo/vendor/symphonia-format-ogg-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"da76614728fa27c003bdcdfbac51396bd8fcbf94c95fe8e62f1d2bac58ef03a4\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-format-wav-0.5.3",
+        "contents": "{\"package\": \"ada3505789516bcf00fc1157c67729eded428b455c27ca370e41f4d785bfa931\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-format-ogg-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-metadata/symphonia-metadata-0.5.3.crate",
-        "sha256": "89c3e1937e31d0e068bbe829f66b2f2bfaa28d056365279e0ef897172c3320c0",
-        "dest": "cargo/vendor/symphonia-metadata-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-format-riff/symphonia-format-riff-0.5.4.crate",
+        "sha256": "05f7be232f962f937f4b7115cbe62c330929345434c834359425e043bfd15f50",
+        "dest": "cargo/vendor/symphonia-format-riff-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"89c3e1937e31d0e068bbe829f66b2f2bfaa28d056365279e0ef897172c3320c0\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-metadata-0.5.3",
+        "contents": "{\"package\": \"05f7be232f962f937f4b7115cbe62c330929345434c834359425e043bfd15f50\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-format-riff-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/symphonia-utils-xiph/symphonia-utils-xiph-0.5.3.crate",
-        "sha256": "a450ca645b80d69aff8b35576cbfdc7f20940b29998202aab910045714c951f8",
-        "dest": "cargo/vendor/symphonia-utils-xiph-0.5.3"
+        "url": "https://static.crates.io/crates/symphonia-metadata/symphonia-metadata-0.5.4.crate",
+        "sha256": "bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c",
+        "dest": "cargo/vendor/symphonia-metadata-0.5.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a450ca645b80d69aff8b35576cbfdc7f20940b29998202aab910045714c951f8\", \"files\": {}}",
-        "dest": "cargo/vendor/symphonia-utils-xiph-0.5.3",
+        "contents": "{\"package\": \"bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-metadata-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/symphonia-utils-xiph/symphonia-utils-xiph-0.5.4.crate",
+        "sha256": "484472580fa49991afda5f6550ece662237b00c6f562c7d9638d1b086ed010fe",
+        "dest": "cargo/vendor/symphonia-utils-xiph-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"484472580fa49991afda5f6550ece662237b00c6f562c7d9638d1b086ed010fe\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-utils-xiph-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6866,66 +6944,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/syn/syn-2.0.49.crate",
-        "sha256": "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496",
-        "dest": "cargo/vendor/syn-2.0.49"
+        "url": "https://static.crates.io/crates/syn/syn-2.0.79.crate",
+        "sha256": "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590",
+        "dest": "cargo/vendor/syn-2.0.79"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496\", \"files\": {}}",
-        "dest": "cargo/vendor/syn-2.0.49",
+        "contents": "{\"package\": \"89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.79",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/system-deps/system-deps-6.2.0.crate",
-        "sha256": "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331",
-        "dest": "cargo/vendor/system-deps-6.2.0"
+        "url": "https://static.crates.io/crates/system-deps/system-deps-6.2.2.crate",
+        "sha256": "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349",
+        "dest": "cargo/vendor/system-deps-6.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331\", \"files\": {}}",
-        "dest": "cargo/vendor/system-deps-6.2.0",
+        "contents": "{\"package\": \"a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349\", \"files\": {}}",
+        "dest": "cargo/vendor/system-deps-6.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tar/tar-0.4.40.crate",
-        "sha256": "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb",
-        "dest": "cargo/vendor/tar-0.4.40"
+        "url": "https://static.crates.io/crates/tar/tar-0.4.42.crate",
+        "sha256": "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020",
+        "dest": "cargo/vendor/tar-0.4.42"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb\", \"files\": {}}",
-        "dest": "cargo/vendor/tar-0.4.40",
+        "contents": "{\"package\": \"4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020\", \"files\": {}}",
+        "dest": "cargo/vendor/tar-0.4.42",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.13.crate",
-        "sha256": "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae",
-        "dest": "cargo/vendor/target-lexicon-0.12.13"
+        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.16.crate",
+        "sha256": "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1",
+        "dest": "cargo/vendor/target-lexicon-0.12.16"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae\", \"files\": {}}",
-        "dest": "cargo/vendor/target-lexicon-0.12.13",
+        "contents": "{\"package\": \"61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/target-lexicon-0.12.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tempfile/tempfile-3.10.0.crate",
-        "sha256": "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67",
-        "dest": "cargo/vendor/tempfile-3.10.0"
+        "url": "https://static.crates.io/crates/tempfile/tempfile-3.13.0.crate",
+        "sha256": "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b",
+        "dest": "cargo/vendor/tempfile-3.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67\", \"files\": {}}",
-        "dest": "cargo/vendor/tempfile-3.10.0",
+        "contents": "{\"package\": \"f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b\", \"files\": {}}",
+        "dest": "cargo/vendor/tempfile-3.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6957,40 +7035,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.57.crate",
-        "sha256": "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b",
-        "dest": "cargo/vendor/thiserror-1.0.57"
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.64.crate",
+        "sha256": "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84",
+        "dest": "cargo/vendor/thiserror-1.0.64"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-1.0.57",
+        "contents": "{\"package\": \"d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-1.0.64",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.57.crate",
-        "sha256": "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81",
-        "dest": "cargo/vendor/thiserror-impl-1.0.57"
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.64.crate",
+        "sha256": "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3",
+        "dest": "cargo/vendor/thiserror-impl-1.0.64"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-impl-1.0.57",
+        "contents": "{\"package\": \"08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-1.0.64",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thread_local/thread_local-1.1.7.crate",
-        "sha256": "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152",
-        "dest": "cargo/vendor/thread_local-1.1.7"
+        "url": "https://static.crates.io/crates/thread_local/thread_local-1.1.8.crate",
+        "sha256": "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c",
+        "dest": "cargo/vendor/thread_local-1.1.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152\", \"files\": {}}",
-        "dest": "cargo/vendor/thread_local-1.1.7",
+        "contents": "{\"package\": \"8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c\", \"files\": {}}",
+        "dest": "cargo/vendor/thread_local-1.1.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7009,14 +7087,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/time/time-0.3.34.crate",
-        "sha256": "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749",
-        "dest": "cargo/vendor/time-0.3.34"
+        "url": "https://static.crates.io/crates/time/time-0.3.36.crate",
+        "sha256": "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885",
+        "dest": "cargo/vendor/time-0.3.36"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749\", \"files\": {}}",
-        "dest": "cargo/vendor/time-0.3.34",
+        "contents": "{\"package\": \"5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885\", \"files\": {}}",
+        "dest": "cargo/vendor/time-0.3.36",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7035,14 +7113,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.17.crate",
-        "sha256": "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774",
-        "dest": "cargo/vendor/time-macros-0.2.17"
+        "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.18.crate",
+        "sha256": "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf",
+        "dest": "cargo/vendor/time-macros-0.2.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774\", \"files\": {}}",
-        "dest": "cargo/vendor/time-macros-0.2.17",
+        "contents": "{\"package\": \"3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf\", \"files\": {}}",
+        "dest": "cargo/vendor/time-macros-0.2.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7074,40 +7152,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tiny-xlib/tiny-xlib-0.2.2.crate",
-        "sha256": "d4098d49269baa034a8d1eae9bd63e9fa532148d772121dace3bcd6a6c98eb6d",
-        "dest": "cargo/vendor/tiny-xlib-0.2.2"
+        "url": "https://static.crates.io/crates/tiny-xlib/tiny-xlib-0.2.3.crate",
+        "sha256": "1d52f22673960ad13af14ff4025997312def1223bfa7c8e4949d099e6b3d5d1c",
+        "dest": "cargo/vendor/tiny-xlib-0.2.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d4098d49269baa034a8d1eae9bd63e9fa532148d772121dace3bcd6a6c98eb6d\", \"files\": {}}",
-        "dest": "cargo/vendor/tiny-xlib-0.2.2",
+        "contents": "{\"package\": \"1d52f22673960ad13af14ff4025997312def1223bfa7c8e4949d099e6b3d5d1c\", \"files\": {}}",
+        "dest": "cargo/vendor/tiny-xlib-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tinystr/tinystr-0.7.5.crate",
-        "sha256": "83c02bf3c538ab32ba913408224323915f4ef9a6d61c0e85d493f355921c0ece",
-        "dest": "cargo/vendor/tinystr-0.7.5"
+        "url": "https://static.crates.io/crates/tinystr/tinystr-0.7.6.crate",
+        "sha256": "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f",
+        "dest": "cargo/vendor/tinystr-0.7.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"83c02bf3c538ab32ba913408224323915f4ef9a6d61c0e85d493f355921c0ece\", \"files\": {}}",
-        "dest": "cargo/vendor/tinystr-0.7.5",
+        "contents": "{\"package\": \"9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f\", \"files\": {}}",
+        "dest": "cargo/vendor/tinystr-0.7.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tinyvec/tinyvec-1.6.0.crate",
-        "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
-        "dest": "cargo/vendor/tinyvec-1.6.0"
+        "url": "https://static.crates.io/crates/tinyvec/tinyvec-1.8.0.crate",
+        "sha256": "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938",
+        "dest": "cargo/vendor/tinyvec-1.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50\", \"files\": {}}",
-        "dest": "cargo/vendor/tinyvec-1.6.0",
+        "contents": "{\"package\": \"445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938\", \"files\": {}}",
+        "dest": "cargo/vendor/tinyvec-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7139,66 +7217,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml/toml-0.8.10.crate",
-        "sha256": "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290",
-        "dest": "cargo/vendor/toml-0.8.10"
+        "url": "https://static.crates.io/crates/toml/toml-0.8.19.crate",
+        "sha256": "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e",
+        "dest": "cargo/vendor/toml-0.8.19"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290\", \"files\": {}}",
-        "dest": "cargo/vendor/toml-0.8.10",
+        "contents": "{\"package\": \"a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.8.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.5.crate",
-        "sha256": "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1",
-        "dest": "cargo/vendor/toml_datetime-0.6.5"
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.8.crate",
+        "sha256": "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41",
+        "dest": "cargo/vendor/toml_datetime-0.6.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_datetime-0.6.5",
+        "contents": "{\"package\": \"0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-0.6.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.19.15.crate",
-        "sha256": "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421",
-        "dest": "cargo/vendor/toml_edit-0.19.15"
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.22.22.crate",
+        "sha256": "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5",
+        "dest": "cargo/vendor/toml_edit-0.22.22"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.19.15",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.21.1.crate",
-        "sha256": "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1",
-        "dest": "cargo/vendor/toml_edit-0.21.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.21.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.22.6.crate",
-        "sha256": "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6",
-        "dest": "cargo/vendor/toml_edit-0.22.6"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.22.6",
+        "contents": "{\"package\": \"4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.22.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7269,14 +7321,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/transpose/transpose-0.2.2.crate",
-        "sha256": "e6522d49d03727ffb138ae4cbc1283d3774f0d10aa7f9bf52e6784c45daf9b23",
-        "dest": "cargo/vendor/transpose-0.2.2"
+        "url": "https://static.crates.io/crates/transpose/transpose-0.2.3.crate",
+        "sha256": "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e",
+        "dest": "cargo/vendor/transpose-0.2.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e6522d49d03727ffb138ae4cbc1283d3774f0d10aa7f9bf52e6784c45daf9b23\", \"files\": {}}",
-        "dest": "cargo/vendor/transpose-0.2.2",
+        "contents": "{\"package\": \"1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e\", \"files\": {}}",
+        "dest": "cargo/vendor/transpose-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7308,14 +7360,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.20.0.crate",
-        "sha256": "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4",
-        "dest": "cargo/vendor/ttf-parser-0.20.0"
+        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.21.1.crate",
+        "sha256": "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8",
+        "dest": "cargo/vendor/ttf-parser-0.21.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4\", \"files\": {}}",
-        "dest": "cargo/vendor/ttf-parser-0.20.0",
+        "contents": "{\"package\": \"2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8\", \"files\": {}}",
+        "dest": "cargo/vendor/ttf-parser-0.21.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.24.1.crate",
+        "sha256": "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a",
+        "dest": "cargo/vendor/ttf-parser-0.24.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a\", \"files\": {}}",
+        "dest": "cargo/vendor/ttf-parser-0.24.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7334,14 +7399,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/type-map/type-map-0.4.0.crate",
-        "sha256": "b6d3364c5e96cb2ad1603037ab253ddd34d7fb72a58bdddf4b7350760fc69a46",
-        "dest": "cargo/vendor/type-map-0.4.0"
+        "url": "https://static.crates.io/crates/type-map/type-map-0.5.0.crate",
+        "sha256": "deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f",
+        "dest": "cargo/vendor/type-map-0.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b6d3364c5e96cb2ad1603037ab253ddd34d7fb72a58bdddf4b7350760fc69a46\", \"files\": {}}",
-        "dest": "cargo/vendor/type-map-0.4.0",
+        "contents": "{\"package\": \"deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f\", \"files\": {}}",
+        "dest": "cargo/vendor/type-map-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7373,14 +7438,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/udev/udev-0.7.0.crate",
-        "sha256": "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a",
-        "dest": "cargo/vendor/udev-0.7.0"
+        "url": "https://static.crates.io/crates/udev/udev-0.9.0.crate",
+        "sha256": "8ba005bcd5b1158ae3cd815905990e8b6ee4ba9ee7adbab6d7b58d389ad09c93",
+        "dest": "cargo/vendor/udev-0.9.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a\", \"files\": {}}",
-        "dest": "cargo/vendor/udev-0.7.0",
+        "contents": "{\"package\": \"8ba005bcd5b1158ae3cd815905990e8b6ee4ba9ee7adbab6d7b58d389ad09c93\", \"files\": {}}",
+        "dest": "cargo/vendor/udev-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7399,27 +7464,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unic-langid/unic-langid-0.9.4.crate",
-        "sha256": "238722e6d794ed130f91f4ea33e01fcff4f188d92337a21297892521c72df516",
-        "dest": "cargo/vendor/unic-langid-0.9.4"
+        "url": "https://static.crates.io/crates/unic-langid/unic-langid-0.9.5.crate",
+        "sha256": "23dd9d1e72a73b25e07123a80776aae3e7b0ec461ef94f9151eed6ec88005a44",
+        "dest": "cargo/vendor/unic-langid-0.9.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"238722e6d794ed130f91f4ea33e01fcff4f188d92337a21297892521c72df516\", \"files\": {}}",
-        "dest": "cargo/vendor/unic-langid-0.9.4",
+        "contents": "{\"package\": \"23dd9d1e72a73b25e07123a80776aae3e7b0ec461ef94f9151eed6ec88005a44\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-langid-0.9.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unic-langid-impl/unic-langid-impl-0.9.4.crate",
-        "sha256": "4bd55a2063fdea4ef1f8633243a7b0524cbeef1905ae04c31a1c9b9775c55bc6",
-        "dest": "cargo/vendor/unic-langid-impl-0.9.4"
+        "url": "https://static.crates.io/crates/unic-langid-impl/unic-langid-impl-0.9.5.crate",
+        "sha256": "0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5",
+        "dest": "cargo/vendor/unic-langid-impl-0.9.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4bd55a2063fdea4ef1f8633243a7b0524cbeef1905ae04c31a1c9b9775c55bc6\", \"files\": {}}",
-        "dest": "cargo/vendor/unic-langid-impl-0.9.4",
+        "contents": "{\"package\": \"0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-langid-impl-0.9.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7451,40 +7516,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-bidi-mirroring/unicode-bidi-mirroring-0.1.0.crate",
-        "sha256": "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694",
-        "dest": "cargo/vendor/unicode-bidi-mirroring-0.1.0"
+        "url": "https://static.crates.io/crates/unicode-bidi-mirroring/unicode-bidi-mirroring-0.2.0.crate",
+        "sha256": "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86",
+        "dest": "cargo/vendor/unicode-bidi-mirroring-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-bidi-mirroring-0.1.0",
+        "contents": "{\"package\": \"23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-bidi-mirroring-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-ccc/unicode-ccc-0.1.2.crate",
-        "sha256": "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1",
-        "dest": "cargo/vendor/unicode-ccc-0.1.2"
+        "url": "https://static.crates.io/crates/unicode-ccc/unicode-ccc-0.2.0.crate",
+        "sha256": "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656",
+        "dest": "cargo/vendor/unicode-ccc-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-ccc-0.1.2",
+        "contents": "{\"package\": \"1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ccc-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.12.crate",
-        "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b",
-        "dest": "cargo/vendor/unicode-ident-1.0.12"
+        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.13.crate",
+        "sha256": "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe",
+        "dest": "cargo/vendor/unicode-ident-1.0.13"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-ident-1.0.12",
+        "contents": "{\"package\": \"e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ident-1.0.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7503,53 +7568,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.22.crate",
-        "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
-        "dest": "cargo/vendor/unicode-normalization-0.1.22"
+        "url": "https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.24.crate",
+        "sha256": "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956",
+        "dest": "cargo/vendor/unicode-normalization-0.1.24"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-normalization-0.1.22",
+        "contents": "{\"package\": \"5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-normalization-0.1.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-properties/unicode-properties-0.1.1.crate",
-        "sha256": "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291",
-        "dest": "cargo/vendor/unicode-properties-0.1.1"
+        "url": "https://static.crates.io/crates/unicode-properties/unicode-properties-0.1.3.crate",
+        "sha256": "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0",
+        "dest": "cargo/vendor/unicode-properties-0.1.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-properties-0.1.1",
+        "contents": "{\"package\": \"e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-properties-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-script/unicode-script-0.5.5.crate",
-        "sha256": "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc",
-        "dest": "cargo/vendor/unicode-script-0.5.5"
+        "url": "https://static.crates.io/crates/unicode-script/unicode-script-0.5.7.crate",
+        "sha256": "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f",
+        "dest": "cargo/vendor/unicode-script-0.5.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-script-0.5.5",
+        "contents": "{\"package\": \"9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-script-0.5.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.11.0.crate",
-        "sha256": "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202",
-        "dest": "cargo/vendor/unicode-segmentation-1.11.0"
+        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.12.0.crate",
+        "sha256": "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493",
+        "dest": "cargo/vendor/unicode-segmentation-1.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-segmentation-1.11.0",
+        "contents": "{\"package\": \"f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-segmentation-1.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7568,27 +7633,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.1.11.crate",
-        "sha256": "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85",
-        "dest": "cargo/vendor/unicode-width-0.1.11"
+        "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.1.14.crate",
+        "sha256": "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af",
+        "dest": "cargo/vendor/unicode-width-0.1.14"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-width-0.1.11",
+        "contents": "{\"package\": \"7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-width-0.1.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/url/url-2.5.0.crate",
-        "sha256": "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633",
-        "dest": "cargo/vendor/url-2.5.0"
+        "url": "https://static.crates.io/crates/url/url-2.5.2.crate",
+        "sha256": "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c",
+        "dest": "cargo/vendor/url-2.5.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633\", \"files\": {}}",
-        "dest": "cargo/vendor/url-2.5.0",
+        "contents": "{\"package\": \"22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c\", \"files\": {}}",
+        "dest": "cargo/vendor/url-2.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7607,79 +7672,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/usvg/usvg-0.38.0.crate",
-        "sha256": "377f62b4a3c173de8654c1aa80ab1dac1154e6f13a779a9943e53780120d1625",
-        "dest": "cargo/vendor/usvg-0.38.0"
+        "url": "https://static.crates.io/crates/usvg/usvg-0.42.0.crate",
+        "sha256": "b84ea542ae85c715f07b082438a4231c3760539d902e11d093847a0b22963032",
+        "dest": "cargo/vendor/usvg-0.42.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"377f62b4a3c173de8654c1aa80ab1dac1154e6f13a779a9943e53780120d1625\", \"files\": {}}",
-        "dest": "cargo/vendor/usvg-0.38.0",
+        "contents": "{\"package\": \"b84ea542ae85c715f07b082438a4231c3760539d902e11d093847a0b22963032\", \"files\": {}}",
+        "dest": "cargo/vendor/usvg-0.42.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/usvg-parser/usvg-parser-0.38.0.crate",
-        "sha256": "351a05e6f2023d6b4e946f734240a3927aefdcf930d7d42587a2c8a8869814b0",
-        "dest": "cargo/vendor/usvg-parser-0.38.0"
+        "url": "https://static.crates.io/crates/utf8parse/utf8parse-0.2.2.crate",
+        "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
+        "dest": "cargo/vendor/utf8parse-0.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"351a05e6f2023d6b4e946f734240a3927aefdcf930d7d42587a2c8a8869814b0\", \"files\": {}}",
-        "dest": "cargo/vendor/usvg-parser-0.38.0",
+        "contents": "{\"package\": \"06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821\", \"files\": {}}",
+        "dest": "cargo/vendor/utf8parse-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/usvg-text-layout/usvg-text-layout-0.38.0.crate",
-        "sha256": "8c41888b9d5cf431fe852eaf9d047bbde83251b98f1749c2f08b1071e6db46e2",
-        "dest": "cargo/vendor/usvg-text-layout-0.38.0"
+        "url": "https://static.crates.io/crates/uuid/uuid-1.10.0.crate",
+        "sha256": "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314",
+        "dest": "cargo/vendor/uuid-1.10.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8c41888b9d5cf431fe852eaf9d047bbde83251b98f1749c2f08b1071e6db46e2\", \"files\": {}}",
-        "dest": "cargo/vendor/usvg-text-layout-0.38.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/usvg-tree/usvg-tree-0.38.0.crate",
-        "sha256": "18863e0404ed153d6e56362c5b1146db9f4f262a3244e3cf2dbe7d8a85909f05",
-        "dest": "cargo/vendor/usvg-tree-0.38.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"18863e0404ed153d6e56362c5b1146db9f4f262a3244e3cf2dbe7d8a85909f05\", \"files\": {}}",
-        "dest": "cargo/vendor/usvg-tree-0.38.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/utf8parse/utf8parse-0.2.1.crate",
-        "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
-        "dest": "cargo/vendor/utf8parse-0.2.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a\", \"files\": {}}",
-        "dest": "cargo/vendor/utf8parse-0.2.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/uuid/uuid-1.7.0.crate",
-        "sha256": "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a",
-        "dest": "cargo/vendor/uuid-1.7.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a\", \"files\": {}}",
-        "dest": "cargo/vendor/uuid-1.7.0",
+        "contents": "{\"package\": \"81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314\", \"files\": {}}",
+        "dest": "cargo/vendor/uuid-1.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7698,27 +7724,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/version-compare/version-compare-0.1.1.crate",
-        "sha256": "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29",
-        "dest": "cargo/vendor/version-compare-0.1.1"
+        "url": "https://static.crates.io/crates/version-compare/version-compare-0.2.0.crate",
+        "sha256": "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b",
+        "dest": "cargo/vendor/version-compare-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29\", \"files\": {}}",
-        "dest": "cargo/vendor/version-compare-0.1.1",
+        "contents": "{\"package\": \"852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b\", \"files\": {}}",
+        "dest": "cargo/vendor/version-compare-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/version_check/version_check-0.9.4.crate",
-        "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
-        "dest": "cargo/vendor/version_check-0.9.4"
+        "url": "https://static.crates.io/crates/version_check/version_check-0.9.5.crate",
+        "sha256": "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a",
+        "dest": "cargo/vendor/version_check-0.9.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f\", \"files\": {}}",
-        "dest": "cargo/vendor/version_check-0.9.4",
+        "contents": "{\"package\": \"0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a\", \"files\": {}}",
+        "dest": "cargo/vendor/version_check-0.9.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7750,27 +7776,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/vtable/vtable-0.1.11.crate",
-        "sha256": "9f4c7506238561777a1861d3dc3c0001877c475187e7bc4392ea87ebf631fd9c",
-        "dest": "cargo/vendor/vtable-0.1.11"
+        "url": "https://static.crates.io/crates/vtable/vtable-0.2.0.crate",
+        "sha256": "379cd4a9d99f35bcf1687282268b94b59f14b098cba210632605f39709230963",
+        "dest": "cargo/vendor/vtable-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9f4c7506238561777a1861d3dc3c0001877c475187e7bc4392ea87ebf631fd9c\", \"files\": {}}",
-        "dest": "cargo/vendor/vtable-0.1.11",
+        "contents": "{\"package\": \"379cd4a9d99f35bcf1687282268b94b59f14b098cba210632605f39709230963\", \"files\": {}}",
+        "dest": "cargo/vendor/vtable-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/vtable-macro/vtable-macro-0.1.10.crate",
-        "sha256": "6b2b8eecdb8e4284adf5546fc518f048f6dc33e7203dbe36fa93a4add39b31f6",
-        "dest": "cargo/vendor/vtable-macro-0.1.10"
+        "url": "https://static.crates.io/crates/vtable-macro/vtable-macro-0.2.0.crate",
+        "sha256": "68c1b85ec843d3bc60e9d65fa7e00ce6549416a25c267b5ea93e6c81e3aa66e5",
+        "dest": "cargo/vendor/vtable-macro-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6b2b8eecdb8e4284adf5546fc518f048f6dc33e7203dbe36fa93a4add39b31f6\", \"files\": {}}",
-        "dest": "cargo/vendor/vtable-macro-0.1.10",
+        "contents": "{\"package\": \"68c1b85ec843d3bc60e9d65fa7e00ce6549416a25c267b5ea93e6c81e3aa66e5\", \"files\": {}}",
+        "dest": "cargo/vendor/vtable-macro-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7789,27 +7815,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/waker-fn/waker-fn-1.1.1.crate",
-        "sha256": "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690",
-        "dest": "cargo/vendor/waker-fn-1.1.1"
+        "url": "https://static.crates.io/crates/walkdir/walkdir-2.5.0.crate",
+        "sha256": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b",
+        "dest": "cargo/vendor/walkdir-2.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690\", \"files\": {}}",
-        "dest": "cargo/vendor/waker-fn-1.1.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/walkdir/walkdir-2.4.0.crate",
-        "sha256": "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee",
-        "dest": "cargo/vendor/walkdir-2.4.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee\", \"files\": {}}",
-        "dest": "cargo/vendor/walkdir-2.4.0",
+        "contents": "{\"package\": \"29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b\", \"files\": {}}",
+        "dest": "cargo/vendor/walkdir-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7828,105 +7841,105 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.91.crate",
-        "sha256": "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.91"
+        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.93.crate",
+        "sha256": "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.93"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.91",
+        "contents": "{\"package\": \"a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.93",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.91.crate",
-        "sha256": "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.91"
+        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.93.crate",
+        "sha256": "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.93"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.91",
+        "contents": "{\"package\": \"9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.93",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.41.crate",
-        "sha256": "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97",
-        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.41"
+        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.43.crate",
+        "sha256": "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.43"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.41",
+        "contents": "{\"package\": \"61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.43",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.91.crate",
-        "sha256": "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.91"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.93.crate",
+        "sha256": "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.93"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.91",
+        "contents": "{\"package\": \"585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.93",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.91.crate",
-        "sha256": "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.91"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.93.crate",
+        "sha256": "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.93"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.91",
+        "contents": "{\"package\": \"afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.93",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.91.crate",
-        "sha256": "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.91"
+        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.93.crate",
+        "sha256": "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.93"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.91",
+        "contents": "{\"package\": \"c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.93",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-backend/wayland-backend-0.3.3.crate",
-        "sha256": "9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40",
-        "dest": "cargo/vendor/wayland-backend-0.3.3"
+        "url": "https://static.crates.io/crates/wayland-backend/wayland-backend-0.3.7.crate",
+        "sha256": "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6",
+        "dest": "cargo/vendor/wayland-backend-0.3.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-backend-0.3.3",
+        "contents": "{\"package\": \"056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-backend-0.3.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-client/wayland-client-0.31.2.crate",
-        "sha256": "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f",
-        "dest": "cargo/vendor/wayland-client-0.31.2"
+        "url": "https://static.crates.io/crates/wayland-client/wayland-client-0.31.6.crate",
+        "sha256": "e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d",
+        "dest": "cargo/vendor/wayland-client-0.31.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-client-0.31.2",
+        "contents": "{\"package\": \"e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-client-0.31.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7945,118 +7958,105 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-cursor/wayland-cursor-0.31.1.crate",
-        "sha256": "71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba",
-        "dest": "cargo/vendor/wayland-cursor-0.31.1"
+        "url": "https://static.crates.io/crates/wayland-cursor/wayland-cursor-0.31.6.crate",
+        "sha256": "3a94697e66e76c85923b0d28a0c251e8f0666f58fc47d316c0f4da6da75d37cb",
+        "dest": "cargo/vendor/wayland-cursor-0.31.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-cursor-0.31.1",
+        "contents": "{\"package\": \"3a94697e66e76c85923b0d28a0c251e8f0666f58fc47d316c0f4da6da75d37cb\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-cursor-0.31.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-protocols/wayland-protocols-0.31.2.crate",
-        "sha256": "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4",
-        "dest": "cargo/vendor/wayland-protocols-0.31.2"
+        "url": "https://static.crates.io/crates/wayland-protocols/wayland-protocols-0.32.4.crate",
+        "sha256": "2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0",
+        "dest": "cargo/vendor/wayland-protocols-0.32.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-protocols-0.31.2",
+        "contents": "{\"package\": \"2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-0.32.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-protocols-plasma/wayland-protocols-plasma-0.2.0.crate",
-        "sha256": "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479",
-        "dest": "cargo/vendor/wayland-protocols-plasma-0.2.0"
+        "url": "https://static.crates.io/crates/wayland-protocols-plasma/wayland-protocols-plasma-0.3.4.crate",
+        "sha256": "8a0a41a6875e585172495f7a96dfa42ca7e0213868f4f15c313f7c33221a7eff",
+        "dest": "cargo/vendor/wayland-protocols-plasma-0.3.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-protocols-plasma-0.2.0",
+        "contents": "{\"package\": \"8a0a41a6875e585172495f7a96dfa42ca7e0213868f4f15c313f7c33221a7eff\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-plasma-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-protocols-wlr/wayland-protocols-wlr-0.2.0.crate",
-        "sha256": "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6",
-        "dest": "cargo/vendor/wayland-protocols-wlr-0.2.0"
+        "url": "https://static.crates.io/crates/wayland-protocols-wlr/wayland-protocols-wlr-0.3.4.crate",
+        "sha256": "dad87b5fd1b1d3ca2f792df8f686a2a11e3fe1077b71096f7a175ab699f89109",
+        "dest": "cargo/vendor/wayland-protocols-wlr-0.3.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-protocols-wlr-0.2.0",
+        "contents": "{\"package\": \"dad87b5fd1b1d3ca2f792df8f686a2a11e3fe1077b71096f7a175ab699f89109\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-wlr-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.31.1.crate",
-        "sha256": "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283",
-        "dest": "cargo/vendor/wayland-scanner-0.31.1"
+        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.31.5.crate",
+        "sha256": "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3",
+        "dest": "cargo/vendor/wayland-scanner-0.31.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-scanner-0.31.1",
+        "contents": "{\"package\": \"597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-scanner-0.31.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.31.1.crate",
-        "sha256": "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af",
-        "dest": "cargo/vendor/wayland-sys-0.31.1"
+        "url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.31.5.crate",
+        "sha256": "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09",
+        "dest": "cargo/vendor/wayland-sys-0.31.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af\", \"files\": {}}",
-        "dest": "cargo/vendor/wayland-sys-0.31.1",
+        "contents": "{\"package\": \"efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-sys-0.31.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.68.crate",
-        "sha256": "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446",
-        "dest": "cargo/vendor/web-sys-0.3.68"
+        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.70.crate",
+        "sha256": "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0",
+        "dest": "cargo/vendor/web-sys-0.3.70"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446\", \"files\": {}}",
-        "dest": "cargo/vendor/web-sys-0.3.68",
+        "contents": "{\"package\": \"26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0\", \"files\": {}}",
+        "dest": "cargo/vendor/web-sys-0.3.70",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/web-time/web-time-0.2.4.crate",
-        "sha256": "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0",
-        "dest": "cargo/vendor/web-time-0.2.4"
+        "url": "https://static.crates.io/crates/web-time/web-time-1.1.0.crate",
+        "sha256": "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb",
+        "dest": "cargo/vendor/web-time-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0\", \"files\": {}}",
-        "dest": "cargo/vendor/web-time-0.2.4",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/web-time/web-time-1.0.0.crate",
-        "sha256": "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0",
-        "dest": "cargo/vendor/web-time-1.0.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0\", \"files\": {}}",
-        "dest": "cargo/vendor/web-time-1.0.0",
+        "contents": "{\"package\": \"5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb\", \"files\": {}}",
+        "dest": "cargo/vendor/web-time-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8114,27 +8114,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.6.crate",
-        "sha256": "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596",
-        "dest": "cargo/vendor/winapi-util-0.1.6"
+        "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.9.crate",
+        "sha256": "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb",
+        "dest": "cargo/vendor/winapi-util-0.1.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596\", \"files\": {}}",
-        "dest": "cargo/vendor/winapi-util-0.1.6",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winapi-wsapoll/winapi-wsapoll-0.1.1.crate",
-        "sha256": "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e",
-        "dest": "cargo/vendor/winapi-wsapoll-0.1.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e\", \"files\": {}}",
-        "dest": "cargo/vendor/winapi-wsapoll-0.1.1",
+        "contents": "{\"package\": \"cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-util-0.1.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8179,14 +8166,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows/windows-0.52.0.crate",
-        "sha256": "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be",
-        "dest": "cargo/vendor/windows-0.52.0"
+        "url": "https://static.crates.io/crates/windows/windows-0.58.0.crate",
+        "sha256": "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6",
+        "dest": "cargo/vendor/windows-0.58.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be\", \"files\": {}}",
-        "dest": "cargo/vendor/windows-0.52.0",
+        "contents": "{\"package\": \"dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.58.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8200,6 +8187,71 @@
         "type": "inline",
         "contents": "{\"package\": \"33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9\", \"files\": {}}",
         "dest": "cargo/vendor/windows-core-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.58.0.crate",
+        "sha256": "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99",
+        "dest": "cargo/vendor/windows-core-0.58.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-implement/windows-implement-0.58.0.crate",
+        "sha256": "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b",
+        "dest": "cargo/vendor/windows-implement-0.58.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-implement-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-interface/windows-interface-0.58.0.crate",
+        "sha256": "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515",
+        "dest": "cargo/vendor/windows-interface-0.58.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-interface-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-result/windows-result-0.2.0.crate",
+        "sha256": "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e",
+        "dest": "cargo/vendor/windows-result-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-result-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-strings/windows-strings-0.1.0.crate",
+        "sha256": "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10",
+        "dest": "cargo/vendor/windows-strings-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-strings-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8244,6 +8296,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.59.0.crate",
+        "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+        "dest": "cargo/vendor/windows-sys-0.59.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.59.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.42.2.crate",
         "sha256": "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071",
         "dest": "cargo/vendor/windows-targets-0.42.2"
@@ -8270,14 +8335,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.0.crate",
-        "sha256": "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd",
-        "dest": "cargo/vendor/windows-targets-0.52.0"
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.6.crate",
+        "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+        "dest": "cargo/vendor/windows-targets-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd\", \"files\": {}}",
-        "dest": "cargo/vendor/windows-targets-0.52.0",
+        "contents": "{\"package\": \"9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8309,14 +8374,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.0.crate",
-        "sha256": "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea",
-        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.0"
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.6.crate",
+        "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea\", \"files\": {}}",
-        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.0",
+        "contents": "{\"package\": \"32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8348,14 +8413,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.0.crate",
-        "sha256": "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef",
-        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.0"
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.6.crate",
+        "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef\", \"files\": {}}",
-        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.0",
+        "contents": "{\"package\": \"09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8387,14 +8452,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.0.crate",
-        "sha256": "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313",
-        "dest": "cargo/vendor/windows_i686_gnu-0.52.0"
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.6.crate",
+        "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313\", \"files\": {}}",
-        "dest": "cargo/vendor/windows_i686_gnu-0.52.0",
+        "contents": "{\"package\": \"8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.6.crate",
+        "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8426,14 +8504,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.0.crate",
-        "sha256": "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a",
-        "dest": "cargo/vendor/windows_i686_msvc-0.52.0"
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.6.crate",
+        "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a\", \"files\": {}}",
-        "dest": "cargo/vendor/windows_i686_msvc-0.52.0",
+        "contents": "{\"package\": \"240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8465,14 +8543,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.0.crate",
-        "sha256": "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd",
-        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.0"
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.6.crate",
+        "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd\", \"files\": {}}",
-        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.0",
+        "contents": "{\"package\": \"147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8504,14 +8582,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.0.crate",
-        "sha256": "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e",
-        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.0"
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.6.crate",
+        "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e\", \"files\": {}}",
-        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.0",
+        "contents": "{\"package\": \"24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8543,53 +8621,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.0.crate",
-        "sha256": "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04",
-        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.0"
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.6.crate",
+        "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04\", \"files\": {}}",
-        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.0",
+        "contents": "{\"package\": \"589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winit/winit-0.29.10.crate",
-        "sha256": "4c824f11941eeae66ec71111cc2674373c772f482b58939bb4066b642aa2ffcf",
-        "dest": "cargo/vendor/winit-0.29.10"
+        "url": "https://static.crates.io/crates/winit/winit-0.30.5.crate",
+        "sha256": "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67",
+        "dest": "cargo/vendor/winit-0.30.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4c824f11941eeae66ec71111cc2674373c772f482b58939bb4066b642aa2ffcf\", \"files\": {}}",
-        "dest": "cargo/vendor/winit-0.29.10",
+        "contents": "{\"package\": \"0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67\", \"files\": {}}",
+        "dest": "cargo/vendor/winit-0.30.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-0.5.40.crate",
-        "sha256": "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876",
-        "dest": "cargo/vendor/winnow-0.5.40"
+        "url": "https://static.crates.io/crates/winnow/winnow-0.6.20.crate",
+        "sha256": "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b",
+        "dest": "cargo/vendor/winnow-0.6.20"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876\", \"files\": {}}",
-        "dest": "cargo/vendor/winnow-0.5.40",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-0.6.1.crate",
-        "sha256": "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401",
-        "dest": "cargo/vendor/winnow-0.6.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401\", \"files\": {}}",
-        "dest": "cargo/vendor/winnow-0.6.1",
+        "contents": "{\"package\": \"36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.6.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8608,14 +8673,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/x11-clipboard/x11-clipboard-0.9.1.crate",
-        "sha256": "613c2be3e772af2bbb57c5a94413675f5ec668bac00a71ada2ced28c420ef087",
-        "dest": "cargo/vendor/x11-clipboard-0.9.1"
+        "url": "https://static.crates.io/crates/x11-clipboard/x11-clipboard-0.9.2.crate",
+        "sha256": "b98785a09322d7446e28a13203d2cae1059a0dd3dfb32cb06d0a225f023d8286",
+        "dest": "cargo/vendor/x11-clipboard-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"613c2be3e772af2bbb57c5a94413675f5ec668bac00a71ada2ced28c420ef087\", \"files\": {}}",
-        "dest": "cargo/vendor/x11-clipboard-0.9.1",
+        "contents": "{\"package\": \"b98785a09322d7446e28a13203d2cae1059a0dd3dfb32cb06d0a225f023d8286\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-clipboard-0.9.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8634,53 +8699,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/x11rb/x11rb-0.12.0.crate",
-        "sha256": "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a",
-        "dest": "cargo/vendor/x11rb-0.12.0"
+        "url": "https://static.crates.io/crates/x11rb/x11rb-0.13.1.crate",
+        "sha256": "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12",
+        "dest": "cargo/vendor/x11rb-0.13.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a\", \"files\": {}}",
-        "dest": "cargo/vendor/x11rb-0.12.0",
+        "contents": "{\"package\": \"5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-0.13.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/x11rb/x11rb-0.13.0.crate",
-        "sha256": "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a",
-        "dest": "cargo/vendor/x11rb-0.13.0"
+        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.13.1.crate",
+        "sha256": "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d",
+        "dest": "cargo/vendor/x11rb-protocol-0.13.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a\", \"files\": {}}",
-        "dest": "cargo/vendor/x11rb-0.13.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.12.0.crate",
-        "sha256": "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc",
-        "dest": "cargo/vendor/x11rb-protocol-0.12.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc\", \"files\": {}}",
-        "dest": "cargo/vendor/x11rb-protocol-0.12.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.13.0.crate",
-        "sha256": "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34",
-        "dest": "cargo/vendor/x11rb-protocol-0.13.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34\", \"files\": {}}",
-        "dest": "cargo/vendor/x11rb-protocol-0.13.0",
+        "contents": "{\"package\": \"ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-protocol-0.13.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8699,40 +8738,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xcursor/xcursor-0.3.5.crate",
-        "sha256": "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911",
-        "dest": "cargo/vendor/xcursor-0.3.5"
+        "url": "https://static.crates.io/crates/xcursor/xcursor-0.3.8.crate",
+        "sha256": "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61",
+        "dest": "cargo/vendor/xcursor-0.3.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911\", \"files\": {}}",
-        "dest": "cargo/vendor/xcursor-0.3.5",
+        "contents": "{\"package\": \"0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61\", \"files\": {}}",
+        "dest": "cargo/vendor/xcursor-0.3.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xdg-home/xdg-home-1.1.0.crate",
-        "sha256": "21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e",
-        "dest": "cargo/vendor/xdg-home-1.1.0"
+        "url": "https://static.crates.io/crates/xdg-home/xdg-home-1.3.0.crate",
+        "sha256": "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6",
+        "dest": "cargo/vendor/xdg-home-1.3.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e\", \"files\": {}}",
-        "dest": "cargo/vendor/xdg-home-1.1.0",
+        "contents": "{\"package\": \"ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6\", \"files\": {}}",
+        "dest": "cargo/vendor/xdg-home-1.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xkbcommon/xkbcommon-0.7.0.crate",
-        "sha256": "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e",
-        "dest": "cargo/vendor/xkbcommon-0.7.0"
+        "url": "https://static.crates.io/crates/xkbcommon/xkbcommon-0.8.0.crate",
+        "sha256": "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9",
+        "dest": "cargo/vendor/xkbcommon-0.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e\", \"files\": {}}",
-        "dest": "cargo/vendor/xkbcommon-0.7.0",
+        "contents": "{\"package\": \"8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9\", \"files\": {}}",
+        "dest": "cargo/vendor/xkbcommon-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8751,27 +8790,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xkeysym/xkeysym-0.2.0.crate",
-        "sha256": "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621",
-        "dest": "cargo/vendor/xkeysym-0.2.0"
+        "url": "https://static.crates.io/crates/xkeysym/xkeysym-0.2.1.crate",
+        "sha256": "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56",
+        "dest": "cargo/vendor/xkeysym-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621\", \"files\": {}}",
-        "dest": "cargo/vendor/xkeysym-0.2.0",
+        "contents": "{\"package\": \"b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56\", \"files\": {}}",
+        "dest": "cargo/vendor/xkeysym-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.19.crate",
-        "sha256": "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a",
-        "dest": "cargo/vendor/xml-rs-0.8.19"
+        "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.22.crate",
+        "sha256": "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26",
+        "dest": "cargo/vendor/xml-rs-0.8.22"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a\", \"files\": {}}",
-        "dest": "cargo/vendor/xml-rs-0.8.19",
+        "contents": "{\"package\": \"af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26\", \"files\": {}}",
+        "dest": "cargo/vendor/xml-rs-0.8.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8790,14 +8829,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xxhash-rust/xxhash-rust-0.8.10.crate",
-        "sha256": "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03",
-        "dest": "cargo/vendor/xxhash-rust-0.8.10"
+        "url": "https://static.crates.io/crates/xxhash-rust/xxhash-rust-0.8.12.crate",
+        "sha256": "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984",
+        "dest": "cargo/vendor/xxhash-rust-0.8.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03\", \"files\": {}}",
-        "dest": "cargo/vendor/xxhash-rust-0.8.10",
+        "contents": "{\"package\": \"6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984\", \"files\": {}}",
+        "dest": "cargo/vendor/xxhash-rust-0.8.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8816,66 +8855,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zbus/zbus-3.15.0.crate",
-        "sha256": "c45d06ae3b0f9ba1fb2671268b975557d8f5a84bb5ec6e43964f87e763d8bca8",
-        "dest": "cargo/vendor/zbus-3.15.0"
+        "url": "https://static.crates.io/crates/zbus/zbus-4.4.0.crate",
+        "sha256": "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725",
+        "dest": "cargo/vendor/zbus-4.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c45d06ae3b0f9ba1fb2671268b975557d8f5a84bb5ec6e43964f87e763d8bca8\", \"files\": {}}",
-        "dest": "cargo/vendor/zbus-3.15.0",
+        "contents": "{\"package\": \"bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus-4.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-3.15.0.crate",
-        "sha256": "b4a1ba45ed0ad344b85a2bb5a1fe9830aed23d67812ea39a586e7d0136439c7d",
-        "dest": "cargo/vendor/zbus_macros-3.15.0"
+        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-4.4.0.crate",
+        "sha256": "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e",
+        "dest": "cargo/vendor/zbus_macros-4.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b4a1ba45ed0ad344b85a2bb5a1fe9830aed23d67812ea39a586e7d0136439c7d\", \"files\": {}}",
-        "dest": "cargo/vendor/zbus_macros-3.15.0",
+        "contents": "{\"package\": \"267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_macros-4.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zbus_names/zbus_names-2.6.0.crate",
-        "sha256": "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9",
-        "dest": "cargo/vendor/zbus_names-2.6.0"
+        "url": "https://static.crates.io/crates/zbus_names/zbus_names-3.0.0.crate",
+        "sha256": "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c",
+        "dest": "cargo/vendor/zbus_names-3.0.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9\", \"files\": {}}",
-        "dest": "cargo/vendor/zbus_names-2.6.0",
+        "contents": "{\"package\": \"4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_names-3.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.7.32.crate",
-        "sha256": "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be",
-        "dest": "cargo/vendor/zerocopy-0.7.32"
+        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.7.35.crate",
+        "sha256": "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0",
+        "dest": "cargo/vendor/zerocopy-0.7.35"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be\", \"files\": {}}",
-        "dest": "cargo/vendor/zerocopy-0.7.32",
+        "contents": "{\"package\": \"1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-0.7.35",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.7.32.crate",
-        "sha256": "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6",
-        "dest": "cargo/vendor/zerocopy-derive-0.7.32"
+        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.7.35.crate",
+        "sha256": "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e",
+        "dest": "cargo/vendor/zerocopy-derive-0.7.35"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6\", \"files\": {}}",
-        "dest": "cargo/vendor/zerocopy-derive-0.7.32",
+        "contents": "{\"package\": \"fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-derive-0.7.35",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8907,40 +8946,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zvariant/zvariant-3.15.0.crate",
-        "sha256": "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c",
-        "dest": "cargo/vendor/zvariant-3.15.0"
+        "url": "https://static.crates.io/crates/zvariant/zvariant-4.2.0.crate",
+        "sha256": "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe",
+        "dest": "cargo/vendor/zvariant-4.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c\", \"files\": {}}",
-        "dest": "cargo/vendor/zvariant-3.15.0",
+        "contents": "{\"package\": \"2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant-4.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-3.15.0.crate",
-        "sha256": "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd",
-        "dest": "cargo/vendor/zvariant_derive-3.15.0"
+        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-4.2.0.crate",
+        "sha256": "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449",
+        "dest": "cargo/vendor/zvariant_derive-4.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd\", \"files\": {}}",
-        "dest": "cargo/vendor/zvariant_derive-3.15.0",
+        "contents": "{\"package\": \"73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_derive-4.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-1.0.1.crate",
-        "sha256": "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200",
-        "dest": "cargo/vendor/zvariant_utils-1.0.1"
+        "url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-2.1.0.crate",
+        "sha256": "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340",
+        "dest": "cargo/vendor/zvariant_utils-2.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200\", \"files\": {}}",
-        "dest": "cargo/vendor/zvariant_utils-1.0.1",
+        "contents": "{\"package\": \"c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_utils-2.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -2,6 +2,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.23.crate",
+        "sha256": "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225",
+        "dest": "cargo/vendor/ab_glyph-0.2.23"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225\", \"files\": {}}",
+        "dest": "cargo/vendor/ab_glyph-0.2.23",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ab_glyph_rasterizer/ab_glyph_rasterizer-0.1.8.crate",
+        "sha256": "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046",
+        "dest": "cargo/vendor/ab_glyph_rasterizer-0.1.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046\", \"files\": {}}",
+        "dest": "cargo/vendor/ab_glyph_rasterizer-0.1.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/adler/adler-1.0.2.crate",
         "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
         "dest": "cargo/vendor/adler-1.0.2"
@@ -28,14 +54,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/aes/aes-0.8.3.crate",
-        "sha256": "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2",
-        "dest": "cargo/vendor/aes-0.8.3"
+        "url": "https://static.crates.io/crates/aes/aes-0.8.4.crate",
+        "sha256": "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0",
+        "dest": "cargo/vendor/aes-0.8.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2\", \"files\": {}}",
-        "dest": "cargo/vendor/aes-0.8.3",
+        "contents": "{\"package\": \"b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0\", \"files\": {}}",
+        "dest": "cargo/vendor/aes-0.8.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ahash/ahash-0.8.8.crate",
+        "sha256": "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff",
+        "dest": "cargo/vendor/ahash-0.8.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff\", \"files\": {}}",
+        "dest": "cargo/vendor/ahash-0.8.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -49,6 +88,45 @@
         "type": "inline",
         "contents": "{\"package\": \"b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0\", \"files\": {}}",
         "dest": "cargo/vendor/aho-corasick-1.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/allocator-api2/allocator-api2-0.2.16.crate",
+        "sha256": "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5",
+        "dest": "cargo/vendor/allocator-api2-0.2.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5\", \"files\": {}}",
+        "dest": "cargo/vendor/allocator-api2-0.2.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/android-activity/android-activity-0.5.2.crate",
+        "sha256": "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289",
+        "dest": "cargo/vendor/android-activity-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289\", \"files\": {}}",
+        "dest": "cargo/vendor/android-activity-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/android-properties/android-properties-0.2.2.crate",
+        "sha256": "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04",
+        "dest": "cargo/vendor/android-properties-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04\", \"files\": {}}",
+        "dest": "cargo/vendor/android-properties-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -80,79 +158,79 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstream/anstream-0.6.4.crate",
-        "sha256": "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44",
-        "dest": "cargo/vendor/anstream-0.6.4"
+        "url": "https://static.crates.io/crates/anstream/anstream-0.6.12.crate",
+        "sha256": "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540",
+        "dest": "cargo/vendor/anstream-0.6.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44\", \"files\": {}}",
-        "dest": "cargo/vendor/anstream-0.6.4",
+        "contents": "{\"package\": \"96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540\", \"files\": {}}",
+        "dest": "cargo/vendor/anstream-0.6.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstyle/anstyle-1.0.4.crate",
-        "sha256": "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87",
-        "dest": "cargo/vendor/anstyle-1.0.4"
+        "url": "https://static.crates.io/crates/anstyle/anstyle-1.0.6.crate",
+        "sha256": "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc",
+        "dest": "cargo/vendor/anstyle-1.0.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87\", \"files\": {}}",
-        "dest": "cargo/vendor/anstyle-1.0.4",
+        "contents": "{\"package\": \"8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-1.0.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstyle-parse/anstyle-parse-0.2.2.crate",
-        "sha256": "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140",
-        "dest": "cargo/vendor/anstyle-parse-0.2.2"
+        "url": "https://static.crates.io/crates/anstyle-parse/anstyle-parse-0.2.3.crate",
+        "sha256": "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c",
+        "dest": "cargo/vendor/anstyle-parse-0.2.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140\", \"files\": {}}",
-        "dest": "cargo/vendor/anstyle-parse-0.2.2",
+        "contents": "{\"package\": \"c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-parse-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstyle-query/anstyle-query-1.0.0.crate",
-        "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
-        "dest": "cargo/vendor/anstyle-query-1.0.0"
+        "url": "https://static.crates.io/crates/anstyle-query/anstyle-query-1.0.2.crate",
+        "sha256": "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648",
+        "dest": "cargo/vendor/anstyle-query-1.0.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b\", \"files\": {}}",
-        "dest": "cargo/vendor/anstyle-query-1.0.0",
+        "contents": "{\"package\": \"e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-query-1.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anstyle-wincon/anstyle-wincon-3.0.1.crate",
-        "sha256": "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628",
-        "dest": "cargo/vendor/anstyle-wincon-3.0.1"
+        "url": "https://static.crates.io/crates/anstyle-wincon/anstyle-wincon-3.0.2.crate",
+        "sha256": "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7",
+        "dest": "cargo/vendor/anstyle-wincon-3.0.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628\", \"files\": {}}",
-        "dest": "cargo/vendor/anstyle-wincon-3.0.1",
+        "contents": "{\"package\": \"1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-wincon-3.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.75.crate",
-        "sha256": "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6",
-        "dest": "cargo/vendor/anyhow-1.0.75"
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.79.crate",
+        "sha256": "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca",
+        "dest": "cargo/vendor/anyhow-1.0.79"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6\", \"files\": {}}",
-        "dest": "cargo/vendor/anyhow-1.0.75",
+        "contents": "{\"package\": \"080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca\", \"files\": {}}",
+        "dest": "cargo/vendor/anyhow-1.0.79",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -197,14 +275,248 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.73.crate",
-        "sha256": "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0",
-        "dest": "cargo/vendor/async-trait-0.1.73"
+        "url": "https://static.crates.io/crates/as-raw-xcb-connection/as-raw-xcb-connection-1.0.1.crate",
+        "sha256": "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b",
+        "dest": "cargo/vendor/as-raw-xcb-connection-1.0.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0\", \"files\": {}}",
-        "dest": "cargo/vendor/async-trait-0.1.73",
+        "contents": "{\"package\": \"175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b\", \"files\": {}}",
+        "dest": "cargo/vendor/as-raw-xcb-connection-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ash/ash-0.37.3+1.3.251.crate",
+        "sha256": "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a",
+        "dest": "cargo/vendor/ash-0.37.3+1.3.251"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a\", \"files\": {}}",
+        "dest": "cargo/vendor/ash-0.37.3+1.3.251",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ashpd/ashpd-0.6.8.crate",
+        "sha256": "4ac22eda5891cc086690cb6fa10121c0390de0e3b04eb269f2d766b00d3f2d81",
+        "dest": "cargo/vendor/ashpd-0.6.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4ac22eda5891cc086690cb6fa10121c0390de0e3b04eb269f2d766b00d3f2d81\", \"files\": {}}",
+        "dest": "cargo/vendor/ashpd-0.6.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-broadcast/async-broadcast-0.5.1.crate",
+        "sha256": "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b",
+        "dest": "cargo/vendor/async-broadcast-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b\", \"files\": {}}",
+        "dest": "cargo/vendor/async-broadcast-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-channel/async-channel-2.2.0.crate",
+        "sha256": "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3",
+        "dest": "cargo/vendor/async-channel-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3\", \"files\": {}}",
+        "dest": "cargo/vendor/async-channel-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-executor/async-executor-1.8.0.crate",
+        "sha256": "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c",
+        "dest": "cargo/vendor/async-executor-1.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c\", \"files\": {}}",
+        "dest": "cargo/vendor/async-executor-1.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-fs/async-fs-1.6.0.crate",
+        "sha256": "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06",
+        "dest": "cargo/vendor/async-fs-1.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06\", \"files\": {}}",
+        "dest": "cargo/vendor/async-fs-1.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-fs/async-fs-2.1.1.crate",
+        "sha256": "bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1",
+        "dest": "cargo/vendor/async-fs-2.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1\", \"files\": {}}",
+        "dest": "cargo/vendor/async-fs-2.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-io/async-io-1.13.0.crate",
+        "sha256": "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af",
+        "dest": "cargo/vendor/async-io-1.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af\", \"files\": {}}",
+        "dest": "cargo/vendor/async-io-1.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-io/async-io-2.3.1.crate",
+        "sha256": "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65",
+        "dest": "cargo/vendor/async-io-2.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65\", \"files\": {}}",
+        "dest": "cargo/vendor/async-io-2.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-lock/async-lock-2.8.0.crate",
+        "sha256": "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b",
+        "dest": "cargo/vendor/async-lock-2.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b\", \"files\": {}}",
+        "dest": "cargo/vendor/async-lock-2.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-lock/async-lock-3.3.0.crate",
+        "sha256": "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b",
+        "dest": "cargo/vendor/async-lock-3.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b\", \"files\": {}}",
+        "dest": "cargo/vendor/async-lock-3.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-net/async-net-2.0.0.crate",
+        "sha256": "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7",
+        "dest": "cargo/vendor/async-net-2.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7\", \"files\": {}}",
+        "dest": "cargo/vendor/async-net-2.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-process/async-process-1.8.1.crate",
+        "sha256": "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88",
+        "dest": "cargo/vendor/async-process-1.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88\", \"files\": {}}",
+        "dest": "cargo/vendor/async-process-1.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-recursion/async-recursion-1.0.5.crate",
+        "sha256": "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0",
+        "dest": "cargo/vendor/async-recursion-1.0.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0\", \"files\": {}}",
+        "dest": "cargo/vendor/async-recursion-1.0.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-signal/async-signal-0.2.5.crate",
+        "sha256": "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5",
+        "dest": "cargo/vendor/async-signal-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5\", \"files\": {}}",
+        "dest": "cargo/vendor/async-signal-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-task/async-task-4.7.0.crate",
+        "sha256": "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799",
+        "dest": "cargo/vendor/async-task-4.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799\", \"files\": {}}",
+        "dest": "cargo/vendor/async-task-4.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.77.crate",
+        "sha256": "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9",
+        "dest": "cargo/vendor/async-trait-0.1.77"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9\", \"files\": {}}",
+        "dest": "cargo/vendor/async-trait-0.1.77",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atomic-waker/atomic-waker-1.1.2.crate",
+        "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+        "dest": "cargo/vendor/atomic-waker-1.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0\", \"files\": {}}",
+        "dest": "cargo/vendor/atomic-waker-1.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -223,6 +535,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/auto_enums/auto_enums-0.8.5.crate",
+        "sha256": "1899bfcfd9340ceea3533ea157360ba8fa864354eccbceab58e1006ecab35393",
+        "dest": "cargo/vendor/auto_enums-0.8.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1899bfcfd9340ceea3533ea157360ba8fa864354eccbceab58e1006ecab35393\", \"files\": {}}",
+        "dest": "cargo/vendor/auto_enums-0.8.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/autocfg/autocfg-1.1.0.crate",
         "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
         "dest": "cargo/vendor/autocfg-1.1.0"
@@ -236,14 +561,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/base64/base64-0.21.4.crate",
-        "sha256": "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2",
-        "dest": "cargo/vendor/base64-0.21.4"
+        "url": "https://static.crates.io/crates/base64/base64-0.21.7.crate",
+        "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
+        "dest": "cargo/vendor/base64-0.21.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2\", \"files\": {}}",
-        "dest": "cargo/vendor/base64-0.21.4",
+        "contents": "{\"package\": \"9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.21.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -275,6 +600,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bindgen/bindgen-0.69.4.crate",
+        "sha256": "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0",
+        "dest": "cargo/vendor/bindgen-0.69.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0\", \"files\": {}}",
+        "dest": "cargo/vendor/bindgen-0.69.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bit_field/bit_field-0.10.2.crate",
         "sha256": "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61",
         "dest": "cargo/vendor/bit_field-0.10.2"
@@ -301,14 +639,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bitflags/bitflags-2.4.0.crate",
-        "sha256": "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635",
-        "dest": "cargo/vendor/bitflags-2.4.0"
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.4.2.crate",
+        "sha256": "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf",
+        "dest": "cargo/vendor/bitflags-2.4.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635\", \"files\": {}}",
-        "dest": "cargo/vendor/bitflags-2.4.0",
+        "contents": "{\"package\": \"ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-2.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -379,27 +717,92 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.14.0.crate",
-        "sha256": "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec",
-        "dest": "cargo/vendor/bumpalo-3.14.0"
+        "url": "https://static.crates.io/crates/block-sys/block-sys-0.2.1.crate",
+        "sha256": "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7",
+        "dest": "cargo/vendor/block-sys-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec\", \"files\": {}}",
-        "dest": "cargo/vendor/bumpalo-3.14.0",
+        "contents": "{\"package\": \"ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7\", \"files\": {}}",
+        "dest": "cargo/vendor/block-sys-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.14.0.crate",
-        "sha256": "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6",
-        "dest": "cargo/vendor/bytemuck-1.14.0"
+        "url": "https://static.crates.io/crates/block2/block2-0.3.0.crate",
+        "sha256": "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68",
+        "dest": "cargo/vendor/block2-0.3.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6\", \"files\": {}}",
-        "dest": "cargo/vendor/bytemuck-1.14.0",
+        "contents": "{\"package\": \"15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68\", \"files\": {}}",
+        "dest": "cargo/vendor/block2-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/blocking/blocking-1.5.1.crate",
+        "sha256": "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118",
+        "dest": "cargo/vendor/blocking-1.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118\", \"files\": {}}",
+        "dest": "cargo/vendor/blocking-1.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.15.0.crate",
+        "sha256": "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f",
+        "dest": "cargo/vendor/bumpalo-3.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f\", \"files\": {}}",
+        "dest": "cargo/vendor/bumpalo-3.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/by_address/by_address-1.1.0.crate",
+        "sha256": "bf8dba2868114ed769a1f2590fc9ae5eb331175b44313b6c9b922f8f7ca813d0",
+        "dest": "cargo/vendor/by_address-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf8dba2868114ed769a1f2590fc9ae5eb331175b44313b6c9b922f8f7ca813d0\", \"files\": {}}",
+        "dest": "cargo/vendor/by_address-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.14.3.crate",
+        "sha256": "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f",
+        "dest": "cargo/vendor/bytemuck-1.14.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck-1.14.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytemuck_derive/bytemuck_derive-1.5.0.crate",
+        "sha256": "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1",
+        "dest": "cargo/vendor/bytemuck_derive-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck_derive-1.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -413,6 +816,19 @@
         "type": "inline",
         "contents": "{\"package\": \"1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b\", \"files\": {}}",
         "dest": "cargo/vendor/byteorder-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytes/bytes-1.5.0.crate",
+        "sha256": "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223",
+        "dest": "cargo/vendor/bytes-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223\", \"files\": {}}",
+        "dest": "cargo/vendor/bytes-1.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -444,27 +860,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.18.2.crate",
-        "sha256": "1c0466dfa8c0ee78deef390c274ad756801e0a6dbb86c5ef0924a298c5761c4d",
-        "dest": "cargo/vendor/cairo-rs-0.18.2"
+        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.19.2.crate",
+        "sha256": "2650f66005301bd33cc486dec076e1293c4cecf768bc7ba9bf5d2b1be339b99c",
+        "dest": "cargo/vendor/cairo-rs-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1c0466dfa8c0ee78deef390c274ad756801e0a6dbb86c5ef0924a298c5761c4d\", \"files\": {}}",
-        "dest": "cargo/vendor/cairo-rs-0.18.2",
+        "contents": "{\"package\": \"2650f66005301bd33cc486dec076e1293c4cecf768bc7ba9bf5d2b1be339b99c\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-rs-0.19.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.18.2.crate",
-        "sha256": "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51",
-        "dest": "cargo/vendor/cairo-sys-rs-0.18.2"
+        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.19.2.crate",
+        "sha256": "fd3bb3119664efbd78b5e6c93957447944f16bdbced84c17a9f41c7829b81e64",
+        "dest": "cargo/vendor/cairo-sys-rs-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51\", \"files\": {}}",
-        "dest": "cargo/vendor/cairo-sys-rs-0.18.2",
+        "contents": "{\"package\": \"fd3bb3119664efbd78b5e6c93957447944f16bdbced84c17a9f41c7829b81e64\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-sys-rs-0.19.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/calloop/calloop-0.12.4.crate",
+        "sha256": "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298",
+        "dest": "cargo/vendor/calloop-0.12.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298\", \"files\": {}}",
+        "dest": "cargo/vendor/calloop-0.12.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/calloop-wayland-source/calloop-wayland-source-0.2.0.crate",
+        "sha256": "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02",
+        "dest": "cargo/vendor/calloop-wayland-source-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02\", \"files\": {}}",
+        "dest": "cargo/vendor/calloop-wayland-source-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -496,6 +938,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cesu8/cesu8-1.1.0.crate",
+        "sha256": "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c",
+        "dest": "cargo/vendor/cesu8-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c\", \"files\": {}}",
+        "dest": "cargo/vendor/cesu8-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cexpr/cexpr-0.6.0.crate",
+        "sha256": "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766",
+        "dest": "cargo/vendor/cexpr-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766\", \"files\": {}}",
+        "dest": "cargo/vendor/cexpr-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cfb/cfb-0.7.3.crate",
         "sha256": "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f",
         "dest": "cargo/vendor/cfb-0.7.3"
@@ -509,14 +977,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.15.5.crate",
-        "sha256": "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3",
-        "dest": "cargo/vendor/cfg-expr-0.15.5"
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.15.7.crate",
+        "sha256": "fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d",
+        "dest": "cargo/vendor/cfg-expr-0.15.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3\", \"files\": {}}",
-        "dest": "cargo/vendor/cfg-expr-0.15.5",
+        "contents": "{\"package\": \"fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-expr-0.15.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -535,14 +1003,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/chrono/chrono-0.4.31.crate",
-        "sha256": "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38",
-        "dest": "cargo/vendor/chrono-0.4.31"
+        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.1.1.crate",
+        "sha256": "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e",
+        "dest": "cargo/vendor/cfg_aliases-0.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38\", \"files\": {}}",
-        "dest": "cargo/vendor/chrono-0.4.31",
+        "contents": "{\"package\": \"fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg_aliases-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.2.0.crate",
+        "sha256": "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f",
+        "dest": "cargo/vendor/cfg_aliases-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg_aliases-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cgl/cgl-0.3.2.crate",
+        "sha256": "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff",
+        "dest": "cargo/vendor/cgl-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff\", \"files\": {}}",
+        "dest": "cargo/vendor/cgl-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chrono/chrono-0.4.34.crate",
+        "sha256": "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b",
+        "dest": "cargo/vendor/chrono-0.4.34"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b\", \"files\": {}}",
+        "dest": "cargo/vendor/chrono-0.4.34",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -561,53 +1068,144 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap/clap-4.4.6.crate",
-        "sha256": "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956",
-        "dest": "cargo/vendor/clap-4.4.6"
+        "url": "https://static.crates.io/crates/clang-sys/clang-sys-1.7.0.crate",
+        "sha256": "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1",
+        "dest": "cargo/vendor/clang-sys-1.7.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956\", \"files\": {}}",
-        "dest": "cargo/vendor/clap-4.4.6",
+        "contents": "{\"package\": \"67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1\", \"files\": {}}",
+        "dest": "cargo/vendor/clang-sys-1.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap_builder/clap_builder-4.4.6.crate",
-        "sha256": "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45",
-        "dest": "cargo/vendor/clap_builder-4.4.6"
+        "url": "https://static.crates.io/crates/clap/clap-4.5.1.crate",
+        "sha256": "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da",
+        "dest": "cargo/vendor/clap-4.5.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45\", \"files\": {}}",
-        "dest": "cargo/vendor/clap_builder-4.4.6",
+        "contents": "{\"package\": \"c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da\", \"files\": {}}",
+        "dest": "cargo/vendor/clap-4.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap_derive/clap_derive-4.4.2.crate",
-        "sha256": "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873",
-        "dest": "cargo/vendor/clap_derive-4.4.2"
+        "url": "https://static.crates.io/crates/clap_builder/clap_builder-4.5.1.crate",
+        "sha256": "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb",
+        "dest": "cargo/vendor/clap_builder-4.5.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873\", \"files\": {}}",
-        "dest": "cargo/vendor/clap_derive-4.4.2",
+        "contents": "{\"package\": \"9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_builder-4.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap_lex/clap_lex-0.5.1.crate",
-        "sha256": "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961",
-        "dest": "cargo/vendor/clap_lex-0.5.1"
+        "url": "https://static.crates.io/crates/clap_derive/clap_derive-4.5.0.crate",
+        "sha256": "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47",
+        "dest": "cargo/vendor/clap_derive-4.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961\", \"files\": {}}",
-        "dest": "cargo/vendor/clap_lex-0.5.1",
+        "contents": "{\"package\": \"307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_derive-4.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap_lex/clap_lex-0.7.0.crate",
+        "sha256": "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce",
+        "dest": "cargo/vendor/clap_lex-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_lex-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clipboard-win/clipboard-win-3.1.1.crate",
+        "sha256": "9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342",
+        "dest": "cargo/vendor/clipboard-win-3.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342\", \"files\": {}}",
+        "dest": "cargo/vendor/clipboard-win-3.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clru/clru-0.6.1.crate",
+        "sha256": "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807",
+        "dest": "cargo/vendor/clru-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807\", \"files\": {}}",
+        "dest": "cargo/vendor/clru-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cocoa/cocoa-0.25.0.crate",
+        "sha256": "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c",
+        "dest": "cargo/vendor/cocoa-0.25.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c\", \"files\": {}}",
+        "dest": "cargo/vendor/cocoa-0.25.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cocoa-foundation/cocoa-foundation-0.1.2.crate",
+        "sha256": "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7",
+        "dest": "cargo/vendor/cocoa-foundation-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7\", \"files\": {}}",
+        "dest": "cargo/vendor/cocoa-foundation-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/codemap/codemap-0.1.3.crate",
+        "sha256": "b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24",
+        "dest": "cargo/vendor/codemap-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24\", \"files\": {}}",
+        "dest": "cargo/vendor/codemap-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/codemap-diagnostic/codemap-diagnostic-0.1.2.crate",
+        "sha256": "cc20770be05b566a963bf91505e60412c4a2d016d1ef95c5512823bb085a8122",
+        "dest": "cargo/vendor/codemap-diagnostic-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc20770be05b566a963bf91505e60412c4a2d016d1ef95c5512823bb085a8122\", \"files\": {}}",
+        "dest": "cargo/vendor/codemap-diagnostic-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -634,6 +1232,71 @@
         "type": "inline",
         "contents": "{\"package\": \"acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7\", \"files\": {}}",
         "dest": "cargo/vendor/colorchoice-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/combine/combine-4.6.6.crate",
+        "sha256": "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4",
+        "dest": "cargo/vendor/combine-4.6.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4\", \"files\": {}}",
+        "dest": "cargo/vendor/combine-4.6.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.4.0.crate",
+        "sha256": "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363",
+        "dest": "cargo/vendor/concurrent-queue-2.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363\", \"files\": {}}",
+        "dest": "cargo/vendor/concurrent-queue-2.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/console/console-0.15.8.crate",
+        "sha256": "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb",
+        "dest": "cargo/vendor/console-0.15.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb\", \"files\": {}}",
+        "dest": "cargo/vendor/console-0.15.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/const-field-offset/const-field-offset-0.1.3.crate",
+        "sha256": "6304465f16f463cddc572b737c3df93576edd3a6b53f057bd8beeb29f4ef8dfd",
+        "dest": "cargo/vendor/const-field-offset-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6304465f16f463cddc572b737c3df93576edd3a6b53f057bd8beeb29f4ef8dfd\", \"files\": {}}",
+        "dest": "cargo/vendor/const-field-offset-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/const-field-offset-macro/const-field-offset-macro-0.1.3.crate",
+        "sha256": "57aaaad9185d3bcb3afe63549d8ba60b2fb0ea8dc2da83f62dd56805edf56fd1",
+        "dest": "cargo/vendor/const-field-offset-macro-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"57aaaad9185d3bcb3afe63549d8ba60b2fb0ea8dc2da83f62dd56805edf56fd1\", \"files\": {}}",
+        "dest": "cargo/vendor/const-field-offset-macro-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -678,92 +1341,222 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.4.crate",
-        "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
-        "dest": "cargo/vendor/core-foundation-sys-0.8.4"
+        "url": "https://static.crates.io/crates/convert_case/convert_case-0.4.0.crate",
+        "sha256": "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e",
+        "dest": "cargo/vendor/convert_case-0.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa\", \"files\": {}}",
-        "dest": "cargo/vendor/core-foundation-sys-0.8.4",
+        "contents": "{\"package\": \"6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e\", \"files\": {}}",
+        "dest": "cargo/vendor/convert_case-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.9.crate",
-        "sha256": "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1",
-        "dest": "cargo/vendor/cpufeatures-0.2.9"
+        "url": "https://static.crates.io/crates/copypasta/copypasta-0.10.1.crate",
+        "sha256": "deb85422867ca93da58b7f95fb5c0c10f6183ed6e1ef8841568968a896d3a858",
+        "dest": "cargo/vendor/copypasta-0.10.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1\", \"files\": {}}",
-        "dest": "cargo/vendor/cpufeatures-0.2.9",
+        "contents": "{\"package\": \"deb85422867ca93da58b7f95fb5c0c10f6183ed6e1ef8841568968a896d3a858\", \"files\": {}}",
+        "dest": "cargo/vendor/copypasta-0.10.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.3.2.crate",
-        "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
-        "dest": "cargo/vendor/crc32fast-1.3.2"
+        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.4.crate",
+        "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f",
+        "dest": "cargo/vendor/core-foundation-0.9.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d\", \"files\": {}}",
-        "dest": "cargo/vendor/crc32fast-1.3.2",
+        "contents": "{\"package\": \"91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.8.crate",
-        "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
-        "dest": "cargo/vendor/crossbeam-channel-0.5.8"
+        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.6.crate",
+        "sha256": "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-channel-0.5.8",
+        "contents": "{\"package\": \"06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.8.3.crate",
-        "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
-        "dest": "cargo/vendor/crossbeam-deque-0.8.3"
+        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.23.1.crate",
+        "sha256": "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212",
+        "dest": "cargo/vendor/core-graphics-0.23.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-deque-0.8.3",
+        "contents": "{\"package\": \"970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-0.23.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.15.crate",
-        "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
-        "dest": "cargo/vendor/crossbeam-epoch-0.9.15"
+        "url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.1.3.crate",
+        "sha256": "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf",
+        "dest": "cargo/vendor/core-graphics-types-0.1.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-epoch-0.9.15",
+        "contents": "{\"package\": \"45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-types-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.16.crate",
-        "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
-        "dest": "cargo/vendor/crossbeam-utils-0.8.16"
+        "url": "https://static.crates.io/crates/core-text/core-text-20.1.0.crate",
+        "sha256": "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5",
+        "dest": "cargo/vendor/core-text-20.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294\", \"files\": {}}",
-        "dest": "cargo/vendor/crossbeam-utils-0.8.16",
+        "contents": "{\"package\": \"c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5\", \"files\": {}}",
+        "dest": "cargo/vendor/core-text-20.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core2/core2-0.4.0.crate",
+        "sha256": "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505",
+        "dest": "cargo/vendor/core2-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505\", \"files\": {}}",
+        "dest": "cargo/vendor/core2-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/countme/countme-3.0.1.crate",
+        "sha256": "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636",
+        "dest": "cargo/vendor/countme-3.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636\", \"files\": {}}",
+        "dest": "cargo/vendor/countme-3.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.12.crate",
+        "sha256": "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504",
+        "dest": "cargo/vendor/cpufeatures-0.2.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504\", \"files\": {}}",
+        "dest": "cargo/vendor/cpufeatures-0.2.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.4.0.crate",
+        "sha256": "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa",
+        "dest": "cargo/vendor/crc32fast-1.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa\", \"files\": {}}",
+        "dest": "cargo/vendor/crc32fast-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/critical-section/critical-section-1.1.2.crate",
+        "sha256": "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216",
+        "dest": "cargo/vendor/critical-section-1.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216\", \"files\": {}}",
+        "dest": "cargo/vendor/critical-section-1.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.11.crate",
+        "sha256": "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.8.5.crate",
+        "sha256": "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d",
+        "dest": "cargo/vendor/crossbeam-deque-0.8.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-deque-0.8.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.18.crate",
+        "sha256": "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-queue/crossbeam-queue-0.3.11.crate",
+        "sha256": "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35",
+        "dest": "cargo/vendor/crossbeam-queue-0.3.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-queue-0.3.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.19.crate",
+        "sha256": "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -790,6 +1583,58 @@
         "type": "inline",
         "contents": "{\"package\": \"1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3\", \"files\": {}}",
         "dest": "cargo/vendor/crypto-common-0.1.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/css-color-parser2/css-color-parser2-1.0.1.crate",
+        "sha256": "cf8ed1639f4b56ec6f31d007ff66ce4a13099dce5a9995d48368a30d62bf04bd",
+        "dest": "cargo/vendor/css-color-parser2-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf8ed1639f4b56ec6f31d007ff66ce4a13099dce5a9995d48368a30d62bf04bd\", \"files\": {}}",
+        "dest": "cargo/vendor/css-color-parser2-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctor/ctor-0.2.6.crate",
+        "sha256": "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e",
+        "dest": "cargo/vendor/ctor-0.2.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e\", \"files\": {}}",
+        "dest": "cargo/vendor/ctor-0.2.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctrlc/ctrlc-3.4.2.crate",
+        "sha256": "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b",
+        "dest": "cargo/vendor/ctrlc-3.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b\", \"files\": {}}",
+        "dest": "cargo/vendor/ctrlc-3.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cursor-icon/cursor-icon-1.1.0.crate",
+        "sha256": "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991",
+        "dest": "cargo/vendor/cursor-icon-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991\", \"files\": {}}",
+        "dest": "cargo/vendor/cursor-icon-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -834,6 +1679,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dary_heap/dary_heap-0.3.6.crate",
+        "sha256": "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca",
+        "dest": "cargo/vendor/dary_heap-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca\", \"files\": {}}",
+        "dest": "cargo/vendor/dary_heap-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dashmap/dashmap-5.5.3.crate",
         "sha256": "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856",
         "dest": "cargo/vendor/dashmap-5.5.3"
@@ -842,6 +1700,32 @@
         "type": "inline",
         "contents": "{\"package\": \"978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856\", \"files\": {}}",
         "dest": "cargo/vendor/dashmap-5.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/data-encoding/data-encoding-2.5.0.crate",
+        "sha256": "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5",
+        "dest": "cargo/vendor/data-encoding-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5\", \"files\": {}}",
+        "dest": "cargo/vendor/data-encoding-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/data-url/data-url-0.3.1.crate",
+        "sha256": "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a",
+        "dest": "cargo/vendor/data-url-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a\", \"files\": {}}",
+        "dest": "cargo/vendor/data-url-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -886,14 +1770,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/deranged/deranged-0.3.9.crate",
-        "sha256": "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3",
-        "dest": "cargo/vendor/deranged-0.3.9"
+        "url": "https://static.crates.io/crates/deranged/deranged-0.3.11.crate",
+        "sha256": "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4",
+        "dest": "cargo/vendor/deranged-0.3.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3\", \"files\": {}}",
-        "dest": "cargo/vendor/deranged-0.3.9",
+        "contents": "{\"package\": \"b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4\", \"files\": {}}",
+        "dest": "cargo/vendor/deranged-0.3.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derivative/derivative-2.2.0.crate",
+        "sha256": "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b",
+        "dest": "cargo/vendor/derivative-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b\", \"files\": {}}",
+        "dest": "cargo/vendor/derivative-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_more/derive_more-0.99.17.crate",
+        "sha256": "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321",
+        "dest": "cargo/vendor/derive_more-0.99.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-0.99.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_utils/derive_utils-0.14.1.crate",
+        "sha256": "61bb5a1014ce6dfc2a378578509abe775a5aa06bff584a547555d9efdb81b926",
+        "dest": "cargo/vendor/derive_utils-0.14.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"61bb5a1014ce6dfc2a378578509abe775a5aa06bff584a547555d9efdb81b926\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_utils-0.14.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -938,6 +1861,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dispatch/dispatch-0.2.0.crate",
+        "sha256": "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b",
+        "dest": "cargo/vendor/dispatch-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b\", \"files\": {}}",
+        "dest": "cargo/vendor/dispatch-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.4.crate",
         "sha256": "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d",
         "dest": "cargo/vendor/displaydoc-0.2.4"
@@ -946,6 +1882,19 @@
         "type": "inline",
         "contents": "{\"package\": \"487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d\", \"files\": {}}",
         "dest": "cargo/vendor/displaydoc-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlib/dlib-0.5.2.crate",
+        "sha256": "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412",
+        "dest": "cargo/vendor/dlib-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412\", \"files\": {}}",
+        "dest": "cargo/vendor/dlib-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -964,14 +1913,144 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/either/either-1.9.0.crate",
-        "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07",
-        "dest": "cargo/vendor/either-1.9.0"
+        "url": "https://static.crates.io/crates/downcast-rs/downcast-rs-1.2.0.crate",
+        "sha256": "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650",
+        "dest": "cargo/vendor/downcast-rs-1.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07\", \"files\": {}}",
-        "dest": "cargo/vendor/either-1.9.0",
+        "contents": "{\"package\": \"9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650\", \"files\": {}}",
+        "dest": "cargo/vendor/downcast-rs-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm/drm-0.9.0.crate",
+        "sha256": "edf9159ef4bcecd0c5e4cbeb573b8d0037493403d542780dba5d840bbf9df56f",
+        "dest": "cargo/vendor/drm-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"edf9159ef4bcecd0c5e4cbeb573b8d0037493403d542780dba5d840bbf9df56f\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm/drm-0.11.1.crate",
+        "sha256": "a0f8a69e60d75ae7dab4ef26a59ca99f2a89d4c142089b537775ae0c198bdcde",
+        "dest": "cargo/vendor/drm-0.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a0f8a69e60d75ae7dab4ef26a59ca99f2a89d4c142089b537775ae0c198bdcde\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-0.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm-ffi/drm-ffi-0.5.0.crate",
+        "sha256": "1352481b7b90e27a8a1bf8ef6b33cf18b98dba7c410e75c24bb3eef2f0d8d525",
+        "dest": "cargo/vendor/drm-ffi-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1352481b7b90e27a8a1bf8ef6b33cf18b98dba7c410e75c24bb3eef2f0d8d525\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-ffi-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm-ffi/drm-ffi-0.7.1.crate",
+        "sha256": "41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6",
+        "dest": "cargo/vendor/drm-ffi-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-ffi-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm-fourcc/drm-fourcc-2.2.0.crate",
+        "sha256": "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4",
+        "dest": "cargo/vendor/drm-fourcc-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-fourcc-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm-sys/drm-sys-0.4.0.crate",
+        "sha256": "1369f1679d6b706d234c4c1e0613c415c2c74b598a09ad28080ba2474b72e42d",
+        "dest": "cargo/vendor/drm-sys-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1369f1679d6b706d234c4c1e0613c415c2c74b598a09ad28080ba2474b72e42d\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-sys-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/drm-sys/drm-sys-0.6.1.crate",
+        "sha256": "2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176",
+        "dest": "cargo/vendor/drm-sys-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d09ff881f92f118b11105ba5e34ff8f4adf27b30dae8f12e28c193af1c83176\", \"files\": {}}",
+        "dest": "cargo/vendor/drm-sys-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dwrote/dwrote-0.11.0.crate",
+        "sha256": "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b",
+        "dest": "cargo/vendor/dwrote-0.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b\", \"files\": {}}",
+        "dest": "cargo/vendor/dwrote-0.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/either/either-1.10.0.crate",
+        "sha256": "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a",
+        "dest": "cargo/vendor/either-1.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a\", \"files\": {}}",
+        "dest": "cargo/vendor/either-1.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/encode_unicode/encode_unicode-0.3.6.crate",
+        "sha256": "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f",
+        "dest": "cargo/vendor/encode_unicode-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f\", \"files\": {}}",
+        "dest": "cargo/vendor/encode_unicode-0.3.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -990,14 +2069,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/enumn/enumn-0.1.12.crate",
-        "sha256": "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b",
-        "dest": "cargo/vendor/enumn-0.1.12"
+        "url": "https://static.crates.io/crates/enumflags2/enumflags2-0.7.9.crate",
+        "sha256": "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d",
+        "dest": "cargo/vendor/enumflags2-0.7.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b\", \"files\": {}}",
-        "dest": "cargo/vendor/enumn-0.1.12",
+        "contents": "{\"package\": \"3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d\", \"files\": {}}",
+        "dest": "cargo/vendor/enumflags2-0.7.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.9.crate",
+        "sha256": "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4",
+        "dest": "cargo/vendor/enumflags2_derive-0.7.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4\", \"files\": {}}",
+        "dest": "cargo/vendor/enumflags2_derive-0.7.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enumn/enumn-0.1.13.crate",
+        "sha256": "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42",
+        "dest": "cargo/vendor/enumn-0.1.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42\", \"files\": {}}",
+        "dest": "cargo/vendor/enumn-0.1.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1016,27 +2121,131 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/errno/errno-0.3.5.crate",
-        "sha256": "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860",
-        "dest": "cargo/vendor/errno-0.3.5"
+        "url": "https://static.crates.io/crates/errno/errno-0.3.8.crate",
+        "sha256": "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245",
+        "dest": "cargo/vendor/errno-0.3.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860\", \"files\": {}}",
-        "dest": "cargo/vendor/errno-0.3.5",
+        "contents": "{\"package\": \"a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-0.3.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/exr/exr-1.71.0.crate",
-        "sha256": "832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8",
-        "dest": "cargo/vendor/exr-1.71.0"
+        "url": "https://static.crates.io/crates/euclid/euclid-0.22.9.crate",
+        "sha256": "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787",
+        "dest": "cargo/vendor/euclid-0.22.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8\", \"files\": {}}",
-        "dest": "cargo/vendor/exr-1.71.0",
+        "contents": "{\"package\": \"87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787\", \"files\": {}}",
+        "dest": "cargo/vendor/euclid-0.22.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener/event-listener-2.5.3.crate",
+        "sha256": "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0",
+        "dest": "cargo/vendor/event-listener-2.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-2.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener/event-listener-3.1.0.crate",
+        "sha256": "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2",
+        "dest": "cargo/vendor/event-listener-3.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-3.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener/event-listener-4.0.3.crate",
+        "sha256": "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e",
+        "dest": "cargo/vendor/event-listener-4.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-4.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener/event-listener-5.1.0.crate",
+        "sha256": "b7ad6fd685ce13acd6d9541a30f6db6567a7a24c9ffd4ba2955d29e3f22c8b27",
+        "dest": "cargo/vendor/event-listener-5.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7ad6fd685ce13acd6d9541a30f6db6567a7a24c9ffd4ba2955d29e3f22c8b27\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-5.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.4.0.crate",
+        "sha256": "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3",
+        "dest": "cargo/vendor/event-listener-strategy-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-strategy-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.5.0.crate",
+        "sha256": "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291",
+        "dest": "cargo/vendor/event-listener-strategy-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-strategy-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/exr/exr-1.72.0.crate",
+        "sha256": "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4",
+        "dest": "cargo/vendor/exr-1.72.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4\", \"files\": {}}",
+        "dest": "cargo/vendor/exr-1.72.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fastrand/fastrand-1.9.0.crate",
+        "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
+        "dest": "cargo/vendor/fastrand-1.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be\", \"files\": {}}",
+        "dest": "cargo/vendor/fastrand-1.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1081,14 +2290,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.0.crate",
-        "sha256": "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10",
-        "dest": "cargo/vendor/fdeflate-0.3.0"
+        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.4.crate",
+        "sha256": "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645",
+        "dest": "cargo/vendor/fdeflate-0.3.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10\", \"files\": {}}",
-        "dest": "cargo/vendor/fdeflate-0.3.0",
+        "contents": "{\"package\": \"4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645\", \"files\": {}}",
+        "dest": "cargo/vendor/fdeflate-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/femtovg/femtovg-0.8.2.crate",
+        "sha256": "18ab822e58e8bc2b89840dc5dde49afe39302e129c60d39c8520200c085404a7",
+        "dest": "cargo/vendor/femtovg-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"18ab822e58e8bc2b89840dc5dde49afe39302e129c60d39c8520200c085404a7\", \"files\": {}}",
+        "dest": "cargo/vendor/femtovg-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1115,6 +2337,19 @@
         "type": "inline",
         "contents": "{\"package\": \"38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f\", \"files\": {}}",
         "dest": "cargo/vendor/field-offset-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/filetime/filetime-0.2.23.crate",
+        "sha256": "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd",
+        "dest": "cargo/vendor/filetime-0.2.23"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd\", \"files\": {}}",
+        "dest": "cargo/vendor/filetime-0.2.23",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1154,6 +2389,19 @@
         "type": "inline",
         "contents": "{\"package\": \"46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e\", \"files\": {}}",
         "dest": "cargo/vendor/flate2-1.0.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/float-cmp/float-cmp-0.9.0.crate",
+        "sha256": "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4",
+        "dest": "cargo/vendor/float-cmp-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4\", \"files\": {}}",
+        "dest": "cargo/vendor/float-cmp-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1237,14 +2485,92 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.2.0.crate",
-        "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
-        "dest": "cargo/vendor/form_urlencoded-1.2.0"
+        "url": "https://static.crates.io/crates/fontconfig-parser/fontconfig-parser-0.5.6.crate",
+        "sha256": "6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d",
+        "dest": "cargo/vendor/fontconfig-parser-0.5.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652\", \"files\": {}}",
-        "dest": "cargo/vendor/form_urlencoded-1.2.0",
+        "contents": "{\"package\": \"6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d\", \"files\": {}}",
+        "dest": "cargo/vendor/fontconfig-parser-0.5.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fontdb/fontdb-0.16.1.crate",
+        "sha256": "3890d0893c8253d3eb98337af18b3e1a10a9b2958f2a164b53a93fb3a3049e72",
+        "dest": "cargo/vendor/fontdb-0.16.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3890d0893c8253d3eb98337af18b3e1a10a9b2958f2a164b53a93fb3a3049e72\", \"files\": {}}",
+        "dest": "cargo/vendor/fontdb-0.16.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fontdue/fontdue-0.8.0.crate",
+        "sha256": "9099a2f86b8e674b75d03ff154b3fe4c5208ed249ced8d69cc313a9fa40bb488",
+        "dest": "cargo/vendor/fontdue-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9099a2f86b8e674b75d03ff154b3fe4c5208ed249ced8d69cc313a9fa40bb488\", \"files\": {}}",
+        "dest": "cargo/vendor/fontdue-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.5.0.crate",
+        "sha256": "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965",
+        "dest": "cargo/vendor/foreign-types-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-macros/foreign-types-macros-0.2.3.crate",
+        "sha256": "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.3.1.crate",
+        "sha256": "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.2.1.crate",
+        "sha256": "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456",
+        "dest": "cargo/vendor/form_urlencoded-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456\", \"files\": {}}",
+        "dest": "cargo/vendor/form_urlencoded-1.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1276,196 +2602,248 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fun_time/fun_time-0.3.3.crate",
-        "sha256": "783fdd8402ab5955698d66b0ba307bb2d3b3bfb911a4dfe7bd6bbc7f140be6a5",
-        "dest": "cargo/vendor/fun_time-0.3.3"
+        "url": "https://static.crates.io/crates/fun_time/fun_time-0.3.4.crate",
+        "sha256": "bee194d43605ea83cca7af42af5f9001fab1a8e2220cb8a012e21dda6167fdb0",
+        "dest": "cargo/vendor/fun_time-0.3.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"783fdd8402ab5955698d66b0ba307bb2d3b3bfb911a4dfe7bd6bbc7f140be6a5\", \"files\": {}}",
-        "dest": "cargo/vendor/fun_time-0.3.3",
+        "contents": "{\"package\": \"bee194d43605ea83cca7af42af5f9001fab1a8e2220cb8a012e21dda6167fdb0\", \"files\": {}}",
+        "dest": "cargo/vendor/fun_time-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fun_time_derive/fun_time_derive-0.3.3.crate",
-        "sha256": "a3d89b974360ce9cd00ef9dd26353bc6f1ec9ff12d95e741ad83b36385f3a736",
-        "dest": "cargo/vendor/fun_time_derive-0.3.3"
+        "url": "https://static.crates.io/crates/fun_time_derive/fun_time_derive-0.3.4.crate",
+        "sha256": "71555fd2db00938d82d29d8fa62a2ae80aed2c162c328d775f79e98d9212f013",
+        "dest": "cargo/vendor/fun_time_derive-0.3.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a3d89b974360ce9cd00ef9dd26353bc6f1ec9ff12d95e741ad83b36385f3a736\", \"files\": {}}",
-        "dest": "cargo/vendor/fun_time_derive-0.3.3",
+        "contents": "{\"package\": \"71555fd2db00938d82d29d8fa62a2ae80aed2c162c328d775f79e98d9212f013\", \"files\": {}}",
+        "dest": "cargo/vendor/fun_time_derive-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures/futures-0.3.28.crate",
-        "sha256": "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40",
-        "dest": "cargo/vendor/futures-0.3.28"
+        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.30.crate",
+        "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
+        "dest": "cargo/vendor/futures-channel-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-0.3.28",
+        "contents": "{\"package\": \"eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-channel-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.28.crate",
-        "sha256": "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2",
-        "dest": "cargo/vendor/futures-channel-0.3.28"
+        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.30.crate",
+        "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
+        "dest": "cargo/vendor/futures-core-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-channel-0.3.28",
+        "contents": "{\"package\": \"dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-core-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.28.crate",
-        "sha256": "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c",
-        "dest": "cargo/vendor/futures-core-0.3.28"
+        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.30.crate",
+        "sha256": "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d",
+        "dest": "cargo/vendor/futures-executor-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-core-0.3.28",
+        "contents": "{\"package\": \"a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-executor-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.28.crate",
-        "sha256": "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0",
-        "dest": "cargo/vendor/futures-executor-0.3.28"
+        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.30.crate",
+        "sha256": "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1",
+        "dest": "cargo/vendor/futures-io-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-executor-0.3.28",
+        "contents": "{\"package\": \"a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-io-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.28.crate",
-        "sha256": "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964",
-        "dest": "cargo/vendor/futures-io-0.3.28"
+        "url": "https://static.crates.io/crates/futures-lite/futures-lite-1.13.0.crate",
+        "sha256": "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce",
+        "dest": "cargo/vendor/futures-lite-1.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-io-0.3.28",
+        "contents": "{\"package\": \"49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-lite-1.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.28.crate",
-        "sha256": "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72",
-        "dest": "cargo/vendor/futures-macro-0.3.28"
+        "url": "https://static.crates.io/crates/futures-lite/futures-lite-2.2.0.crate",
+        "sha256": "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba",
+        "dest": "cargo/vendor/futures-lite-2.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-macro-0.3.28",
+        "contents": "{\"package\": \"445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-lite-2.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.28.crate",
-        "sha256": "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e",
-        "dest": "cargo/vendor/futures-sink-0.3.28"
+        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.30.crate",
+        "sha256": "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac",
+        "dest": "cargo/vendor/futures-macro-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-sink-0.3.28",
+        "contents": "{\"package\": \"87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-macro-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.28.crate",
-        "sha256": "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65",
-        "dest": "cargo/vendor/futures-task-0.3.28"
+        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.30.crate",
+        "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5",
+        "dest": "cargo/vendor/futures-sink-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-task-0.3.28",
+        "contents": "{\"package\": \"9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-sink-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.28.crate",
-        "sha256": "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533",
-        "dest": "cargo/vendor/futures-util-0.3.28"
+        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.30.crate",
+        "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004",
+        "dest": "cargo/vendor/futures-task-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533\", \"files\": {}}",
-        "dest": "cargo/vendor/futures-util-0.3.28",
+        "contents": "{\"package\": \"38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-task-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.18.0.crate",
-        "sha256": "bbc9c2ed73a81d556b65d08879ba4ee58808a6b1927ce915262185d6d547c6f3",
-        "dest": "cargo/vendor/gdk-pixbuf-0.18.0"
+        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.30.crate",
+        "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
+        "dest": "cargo/vendor/futures-util-0.3.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bbc9c2ed73a81d556b65d08879ba4ee58808a6b1927ce915262185d6d547c6f3\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk-pixbuf-0.18.0",
+        "contents": "{\"package\": \"3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-util-0.3.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.18.0.crate",
-        "sha256": "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.18.0"
+        "url": "https://static.crates.io/crates/gbm/gbm-0.12.0.crate",
+        "sha256": "f2ec389cda876966cf824111bf6e533fb934c711d473498279964a990853b3c6",
+        "dest": "cargo/vendor/gbm-0.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.18.0",
+        "contents": "{\"package\": \"f2ec389cda876966cf824111bf6e533fb934c711d473498279964a990853b3c6\", \"files\": {}}",
+        "dest": "cargo/vendor/gbm-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk4/gdk4-0.7.3.crate",
-        "sha256": "7edb019ad581f8ecf8ea8e4baa6df7c483a95b5a59be3140be6a9c3b0c632af6",
-        "dest": "cargo/vendor/gdk4-0.7.3"
+        "url": "https://static.crates.io/crates/gbm-sys/gbm-sys-0.2.2.crate",
+        "sha256": "b63eba9b9b7a231514482deb08759301c9f9f049ac6869403f381834ebfeaf67",
+        "dest": "cargo/vendor/gbm-sys-0.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7edb019ad581f8ecf8ea8e4baa6df7c483a95b5a59be3140be6a9c3b0c632af6\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk4-0.7.3",
+        "contents": "{\"package\": \"b63eba9b9b7a231514482deb08759301c9f9f049ac6869403f381834ebfeaf67\", \"files\": {}}",
+        "dest": "cargo/vendor/gbm-sys-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.7.2.crate",
-        "sha256": "dbab43f332a3cf1df9974da690b5bb0e26720ed09a228178ce52175372dcfef0",
-        "dest": "cargo/vendor/gdk4-sys-0.7.2"
+        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.19.2.crate",
+        "sha256": "f6a23f8a0b5090494fd04924662d463f8386cc678dd3915015a838c1a3679b92",
+        "dest": "cargo/vendor/gdk-pixbuf-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dbab43f332a3cf1df9974da690b5bb0e26720ed09a228178ce52175372dcfef0\", \"files\": {}}",
-        "dest": "cargo/vendor/gdk4-sys-0.7.2",
+        "contents": "{\"package\": \"f6a23f8a0b5090494fd04924662d463f8386cc678dd3915015a838c1a3679b92\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-0.19.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.19.0.crate",
+        "sha256": "3dcbd04c1b2c4834cc008b4828bc917d062483b88d26effde6342e5622028f96",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3dcbd04c1b2c4834cc008b4828bc917d062483b88d26effde6342e5622028f96\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk4/gdk4-0.8.0.crate",
+        "sha256": "6771942f85a2beaa220c64739395e4401b9fab4a52aba9b503fa1e6ed4d4d806",
+        "dest": "cargo/vendor/gdk4-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6771942f85a2beaa220c64739395e4401b9fab4a52aba9b503fa1e6ed4d4d806\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk4-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.8.0.crate",
+        "sha256": "1eb95854fab65072023a7814434f003db571d6e45c287c0b0c540c1c78bdf6ae",
+        "dest": "cargo/vendor/gdk4-sys-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1eb95854fab65072023a7814434f003db571d6e45c287c0b0c540c1c78bdf6ae\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk4-sys-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/generational-arena/generational-arena-0.2.9.crate",
+        "sha256": "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7",
+        "dest": "cargo/vendor/generational-arena-0.2.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7\", \"files\": {}}",
+        "dest": "cargo/vendor/generational-arena-0.2.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1497,14 +2875,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.10.crate",
-        "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
-        "dest": "cargo/vendor/getrandom-0.2.10"
+        "url": "https://static.crates.io/crates/gethostname/gethostname-0.3.0.crate",
+        "sha256": "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177",
+        "dest": "cargo/vendor/gethostname-0.3.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427\", \"files\": {}}",
-        "dest": "cargo/vendor/getrandom-0.2.10",
+        "contents": "{\"package\": \"bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177\", \"files\": {}}",
+        "dest": "cargo/vendor/gethostname-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gethostname/gethostname-0.4.3.crate",
+        "sha256": "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818",
+        "dest": "cargo/vendor/gethostname-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818\", \"files\": {}}",
+        "dest": "cargo/vendor/gethostname-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.12.crate",
+        "sha256": "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5",
+        "dest": "cargo/vendor/getrandom-0.2.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.2.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1523,66 +2927,79 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gio/gio-0.18.2.crate",
-        "sha256": "57052f84e8e5999b258e8adf8f5f2af0ac69033864936b8b6838321db2f759b1",
-        "dest": "cargo/vendor/gio-0.18.2"
+        "url": "https://static.crates.io/crates/gio/gio-0.19.2.crate",
+        "sha256": "2eae10b27b6dd27e22ed0d812c6387deba295e6fc004a8b379e459b663b05a02",
+        "dest": "cargo/vendor/gio-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"57052f84e8e5999b258e8adf8f5f2af0ac69033864936b8b6838321db2f759b1\", \"files\": {}}",
-        "dest": "cargo/vendor/gio-0.18.2",
+        "contents": "{\"package\": \"2eae10b27b6dd27e22ed0d812c6387deba295e6fc004a8b379e459b663b05a02\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-0.19.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.18.1.crate",
-        "sha256": "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2",
-        "dest": "cargo/vendor/gio-sys-0.18.1"
+        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.19.0.crate",
+        "sha256": "bcf8e1d9219bb294636753d307b030c1e8a032062cba74f493c431a5c8b81ce4",
+        "dest": "cargo/vendor/gio-sys-0.19.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2\", \"files\": {}}",
-        "dest": "cargo/vendor/gio-sys-0.18.1",
+        "contents": "{\"package\": \"bcf8e1d9219bb294636753d307b030c1e8a032062cba74f493c431a5c8b81ce4\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-sys-0.19.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib/glib-0.18.2.crate",
-        "sha256": "1c316afb01ce8067c5eaab1fc4f2cd47dc21ce7b6296358605e2ffab23ccbd19",
-        "dest": "cargo/vendor/glib-0.18.2"
+        "url": "https://static.crates.io/crates/gl_generator/gl_generator-0.14.0.crate",
+        "sha256": "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d",
+        "dest": "cargo/vendor/gl_generator-0.14.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1c316afb01ce8067c5eaab1fc4f2cd47dc21ce7b6296358605e2ffab23ccbd19\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-0.18.2",
+        "contents": "{\"package\": \"1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d\", \"files\": {}}",
+        "dest": "cargo/vendor/gl_generator-0.14.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.18.2.crate",
-        "sha256": "f8da903822b136d42360518653fcf154455defc437d3e7a81475bf9a95ff1e47",
-        "dest": "cargo/vendor/glib-macros-0.18.2"
+        "url": "https://static.crates.io/crates/glib/glib-0.19.2.crate",
+        "sha256": "ab9e86540b5d8402e905ad4ce7d6aa544092131ab564f3102175af176b90a053",
+        "dest": "cargo/vendor/glib-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f8da903822b136d42360518653fcf154455defc437d3e7a81475bf9a95ff1e47\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-macros-0.18.2",
+        "contents": "{\"package\": \"ab9e86540b5d8402e905ad4ce7d6aa544092131ab564f3102175af176b90a053\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-0.19.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.18.1.crate",
-        "sha256": "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898",
-        "dest": "cargo/vendor/glib-sys-0.18.1"
+        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.19.2.crate",
+        "sha256": "0f5897ca27a83e4cdc7b4666850bade0a2e73e17689aabafcc9acddad9d823b8",
+        "dest": "cargo/vendor/glib-macros-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898\", \"files\": {}}",
-        "dest": "cargo/vendor/glib-sys-0.18.1",
+        "contents": "{\"package\": \"0f5897ca27a83e4cdc7b4666850bade0a2e73e17689aabafcc9acddad9d823b8\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-macros-0.19.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.19.0.crate",
+        "sha256": "630f097773d7c7a0bb3258df4e8157b47dc98bbfa0e60ad9ab56174813feced4",
+        "dest": "cargo/vendor/glib-sys-0.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"630f097773d7c7a0bb3258df4e8157b47dc98bbfa0e60ad9ab56174813feced4\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-sys-0.19.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1601,131 +3018,209 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/globalcache/globalcache-0.2.0.crate",
-        "sha256": "469dba5c15b33d67400508ff1f640e8906fa6c8d5ee80540203eb9029ce475df",
-        "dest": "cargo/vendor/globalcache-0.2.0"
+        "url": "https://static.crates.io/crates/globalcache/globalcache-0.2.2.crate",
+        "sha256": "ccd40efe5b4f0021ca3c36a140cb365563be3c579653b573a5a8ac69bd6f9028",
+        "dest": "cargo/vendor/globalcache-0.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"469dba5c15b33d67400508ff1f640e8906fa6c8d5ee80540203eb9029ce475df\", \"files\": {}}",
-        "dest": "cargo/vendor/globalcache-0.2.0",
+        "contents": "{\"package\": \"ccd40efe5b4f0021ca3c36a140cb365563be3c579653b573a5a8ac69bd6f9028\", \"files\": {}}",
+        "dest": "cargo/vendor/globalcache-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.18.0.crate",
-        "sha256": "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44",
-        "dest": "cargo/vendor/gobject-sys-0.18.0"
+        "url": "https://static.crates.io/crates/glow/glow-0.13.1.crate",
+        "sha256": "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1",
+        "dest": "cargo/vendor/glow-0.13.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44\", \"files\": {}}",
-        "dest": "cargo/vendor/gobject-sys-0.18.0",
+        "contents": "{\"package\": \"bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1\", \"files\": {}}",
+        "dest": "cargo/vendor/glow-0.13.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.18.1.crate",
-        "sha256": "3b2228cda1505613a7a956cca69076892cfbda84fc2b7a62b94a41a272c0c401",
-        "dest": "cargo/vendor/graphene-rs-0.18.1"
+        "url": "https://static.crates.io/crates/glutin/glutin-0.31.3.crate",
+        "sha256": "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746",
+        "dest": "cargo/vendor/glutin-0.31.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3b2228cda1505613a7a956cca69076892cfbda84fc2b7a62b94a41a272c0c401\", \"files\": {}}",
-        "dest": "cargo/vendor/graphene-rs-0.18.1",
+        "contents": "{\"package\": \"18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin-0.31.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.18.1.crate",
-        "sha256": "cc4144cee8fc8788f2a9b73dc5f1d4e1189d1f95305c4cb7bd9c1af1cfa31f59",
-        "dest": "cargo/vendor/graphene-sys-0.18.1"
+        "url": "https://static.crates.io/crates/glutin-winit/glutin-winit-0.4.2.crate",
+        "sha256": "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735",
+        "dest": "cargo/vendor/glutin-winit-0.4.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cc4144cee8fc8788f2a9b73dc5f1d4e1189d1f95305c4cb7bd9c1af1cfa31f59\", \"files\": {}}",
-        "dest": "cargo/vendor/graphene-sys-0.18.1",
+        "contents": "{\"package\": \"1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin-winit-0.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gsk4/gsk4-0.7.3.crate",
-        "sha256": "0d958e351d2f210309b32d081c832d7de0aca0b077aa10d88336c6379bd01f7e",
-        "dest": "cargo/vendor/gsk4-0.7.3"
+        "url": "https://static.crates.io/crates/glutin_egl_sys/glutin_egl_sys-0.6.0.crate",
+        "sha256": "77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd",
+        "dest": "cargo/vendor/glutin_egl_sys-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0d958e351d2f210309b32d081c832d7de0aca0b077aa10d88336c6379bd01f7e\", \"files\": {}}",
-        "dest": "cargo/vendor/gsk4-0.7.3",
+        "contents": "{\"package\": \"77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin_egl_sys-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.7.3.crate",
-        "sha256": "12bd9e3effea989f020e8f1ff3fa3b8c63ba93d43b899c11a118868853a56d55",
-        "dest": "cargo/vendor/gsk4-sys-0.7.3"
+        "url": "https://static.crates.io/crates/glutin_glx_sys/glutin_glx_sys-0.5.0.crate",
+        "sha256": "a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f",
+        "dest": "cargo/vendor/glutin_glx_sys-0.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"12bd9e3effea989f020e8f1ff3fa3b8c63ba93d43b899c11a118868853a56d55\", \"files\": {}}",
-        "dest": "cargo/vendor/gsk4-sys-0.7.3",
+        "contents": "{\"package\": \"a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin_glx_sys-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4/gtk4-0.7.3.crate",
-        "sha256": "5aeb51aa3e9728575a053e1f43543cd9992ac2477e1b186ad824fd4adfb70842",
-        "dest": "cargo/vendor/gtk4-0.7.3"
+        "url": "https://static.crates.io/crates/glutin_wgl_sys/glutin_wgl_sys-0.5.0.crate",
+        "sha256": "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead",
+        "dest": "cargo/vendor/glutin_wgl_sys-0.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5aeb51aa3e9728575a053e1f43543cd9992ac2477e1b186ad824fd4adfb70842\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-0.7.3",
+        "contents": "{\"package\": \"6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead\", \"files\": {}}",
+        "dest": "cargo/vendor/glutin_wgl_sys-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.7.2.crate",
-        "sha256": "d57ec49cf9b657f69a05bca8027cff0a8dfd0c49e812be026fc7311f2163832f",
-        "dest": "cargo/vendor/gtk4-macros-0.7.2"
+        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.19.0.crate",
+        "sha256": "c85e2b1080b9418dd0c58b498da3a5c826030343e0ef07bde6a955d28de54979",
+        "dest": "cargo/vendor/gobject-sys-0.19.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d57ec49cf9b657f69a05bca8027cff0a8dfd0c49e812be026fc7311f2163832f\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-macros-0.7.2",
+        "contents": "{\"package\": \"c85e2b1080b9418dd0c58b498da3a5c826030343e0ef07bde6a955d28de54979\", \"files\": {}}",
+        "dest": "cargo/vendor/gobject-sys-0.19.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.7.3.crate",
-        "sha256": "54d8c4aa23638ce9faa2caf7e2a27d4a1295af2155c8e8d28c4d4eeca7a65eb8",
-        "dest": "cargo/vendor/gtk4-sys-0.7.3"
+        "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.19.2.crate",
+        "sha256": "99e4d388e96c5f29e2b2f67045d229ddf826d0a8d6d282f94ed3b34452222c91",
+        "dest": "cargo/vendor/graphene-rs-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"54d8c4aa23638ce9faa2caf7e2a27d4a1295af2155c8e8d28c4d4eeca7a65eb8\", \"files\": {}}",
-        "dest": "cargo/vendor/gtk4-sys-0.7.3",
+        "contents": "{\"package\": \"99e4d388e96c5f29e2b2f67045d229ddf826d0a8d6d282f94ed3b34452222c91\", \"files\": {}}",
+        "dest": "cargo/vendor/graphene-rs-0.19.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/half/half-2.2.1.crate",
-        "sha256": "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0",
-        "dest": "cargo/vendor/half-2.2.1"
+        "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.19.0.crate",
+        "sha256": "236ed66cc9b18d8adf233716f75de803d0bf6fc806f60d14d948974a12e240d0",
+        "dest": "cargo/vendor/graphene-sys-0.19.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0\", \"files\": {}}",
-        "dest": "cargo/vendor/half-2.2.1",
+        "contents": "{\"package\": \"236ed66cc9b18d8adf233716f75de803d0bf6fc806f60d14d948974a12e240d0\", \"files\": {}}",
+        "dest": "cargo/vendor/graphene-sys-0.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gsk4/gsk4-0.8.0.crate",
+        "sha256": "0e8ce8dee0fd87a11002214b1204ff18c9272fbd530408f0884a0f9b25dc31de",
+        "dest": "cargo/vendor/gsk4-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0e8ce8dee0fd87a11002214b1204ff18c9272fbd530408f0884a0f9b25dc31de\", \"files\": {}}",
+        "dest": "cargo/vendor/gsk4-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.8.0.crate",
+        "sha256": "2660a652da5b662d43924df19ba40d73f015ed427329ef51d2b1360a4e0dc0e4",
+        "dest": "cargo/vendor/gsk4-sys-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2660a652da5b662d43924df19ba40d73f015ed427329ef51d2b1360a4e0dc0e4\", \"files\": {}}",
+        "dest": "cargo/vendor/gsk4-sys-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk4/gtk4-0.8.0.crate",
+        "sha256": "7d26ffa3ec6316ccaa1df62d3e7f5bae1637c0acbb43f250fabef38319f73c64",
+        "dest": "cargo/vendor/gtk4-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7d26ffa3ec6316ccaa1df62d3e7f5bae1637c0acbb43f250fabef38319f73c64\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.8.0.crate",
+        "sha256": "c8b86439e9896f6f3f47c3d8077c5c8205174078760afdabd9098a8e9e937d97",
+        "dest": "cargo/vendor/gtk4-macros-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c8b86439e9896f6f3f47c3d8077c5c8205174078760afdabd9098a8e9e937d97\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-macros-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.8.0.crate",
+        "sha256": "2abc0a6d356d59a3806021829ce6ed3e70bba3509b41a535fedcb09fae13fbc0",
+        "dest": "cargo/vendor/gtk4-sys-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2abc0a6d356d59a3806021829ce6ed3e70bba3509b41a535fedcb09fae13fbc0\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk4-sys-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/half/half-2.3.1.crate",
+        "sha256": "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872",
+        "dest": "cargo/vendor/half-2.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872\", \"files\": {}}",
+        "dest": "cargo/vendor/half-2.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1770,14 +3265,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.1.crate",
-        "sha256": "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12",
-        "dest": "cargo/vendor/hashbrown-0.14.1"
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.13.2.crate",
+        "sha256": "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e",
+        "dest": "cargo/vendor/hashbrown-0.13.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12\", \"files\": {}}",
-        "dest": "cargo/vendor/hashbrown-0.14.1",
+        "contents": "{\"package\": \"43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.13.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.3.crate",
+        "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604",
+        "dest": "cargo/vendor/hashbrown-0.14.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.14.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1796,6 +3304,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.3.6.crate",
+        "sha256": "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd",
+        "dest": "cargo/vendor/hermit-abi-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd\", \"files\": {}}",
+        "dest": "cargo/vendor/hermit-abi-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hex/hex-0.4.3.crate",
+        "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
+        "dest": "cargo/vendor/hex-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70\", \"files\": {}}",
+        "dest": "cargo/vendor/hex-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hmac/hmac-0.12.1.crate",
         "sha256": "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e",
         "dest": "cargo/vendor/hmac-0.12.1"
@@ -1809,6 +3343,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/home/home-0.5.9.crate",
+        "sha256": "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5",
+        "dest": "cargo/vendor/home-0.5.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5\", \"files\": {}}",
+        "dest": "cargo/vendor/home-0.5.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/humansize/humansize-2.1.3.crate",
         "sha256": "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7",
         "dest": "cargo/vendor/humansize-2.1.3"
@@ -1817,6 +3364,123 @@
         "type": "inline",
         "contents": "{\"package\": \"6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7\", \"files\": {}}",
         "dest": "cargo/vendor/humansize-2.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-backend-linuxkms/i-slint-backend-linuxkms-1.4.1.crate",
+        "sha256": "7fff24de728432445a94f890093bd852a7c3fd01ae282e40ae0eab6ea629a66d",
+        "dest": "cargo/vendor/i-slint-backend-linuxkms-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7fff24de728432445a94f890093bd852a7c3fd01ae282e40ae0eab6ea629a66d\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-backend-linuxkms-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-backend-selector/i-slint-backend-selector-1.4.1.crate",
+        "sha256": "1953f792a394a7ad26932b4989646719fb126910029006f7cef40ffd189633d0",
+        "dest": "cargo/vendor/i-slint-backend-selector-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1953f792a394a7ad26932b4989646719fb126910029006f7cef40ffd189633d0\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-backend-selector-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-backend-winit/i-slint-backend-winit-1.4.1.crate",
+        "sha256": "138c36c5c9e12f22fe07f280200cedb5d31e07641e40e3b45376fe2112ead303",
+        "dest": "cargo/vendor/i-slint-backend-winit-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"138c36c5c9e12f22fe07f280200cedb5d31e07641e40e3b45376fe2112ead303\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-backend-winit-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-common/i-slint-common-1.4.1.crate",
+        "sha256": "550e9282fda488b76ce057a728168d1aef947c758f3221b92ae904b167ab008c",
+        "dest": "cargo/vendor/i-slint-common-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"550e9282fda488b76ce057a728168d1aef947c758f3221b92ae904b167ab008c\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-common-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-compiler/i-slint-compiler-1.4.1.crate",
+        "sha256": "25aa2c3525ea761b3e9251f7869e64dce5f483f7ea1a5e04fe7b9a3fb5780dd6",
+        "dest": "cargo/vendor/i-slint-compiler-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"25aa2c3525ea761b3e9251f7869e64dce5f483f7ea1a5e04fe7b9a3fb5780dd6\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-compiler-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-core/i-slint-core-1.4.1.crate",
+        "sha256": "4d40990f7ed42c76799edc0e8cae9a8ffcc77569506a94e86eef81626c7387a7",
+        "dest": "cargo/vendor/i-slint-core-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d40990f7ed42c76799edc0e8cae9a8ffcc77569506a94e86eef81626c7387a7\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-core-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-core-macros/i-slint-core-macros-1.4.1.crate",
+        "sha256": "4f2a4e4c21ed660181abe101b6f141d920e838fec4bc1ff20f7440dc03fb5ad8",
+        "dest": "cargo/vendor/i-slint-core-macros-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4f2a4e4c21ed660181abe101b6f141d920e838fec4bc1ff20f7440dc03fb5ad8\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-core-macros-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-renderer-femtovg/i-slint-renderer-femtovg-1.4.1.crate",
+        "sha256": "337e6ec928bde01baa27d3fdeddd5a33665952aead4d0d9be9818f573a41344c",
+        "dest": "cargo/vendor/i-slint-renderer-femtovg-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"337e6ec928bde01baa27d3fdeddd5a33665952aead4d0d9be9818f573a41344c\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-renderer-femtovg-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/i-slint-renderer-skia/i-slint-renderer-skia-1.4.1.crate",
+        "sha256": "1189ac65d7e31129407e2cfef4009cdea500040a73d8f87505949f82af0939db",
+        "dest": "cargo/vendor/i-slint-renderer-skia-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1189ac65d7e31129407e2cfef4009cdea500040a73d8f87505949f82af0939db\", \"files\": {}}",
+        "dest": "cargo/vendor/i-slint-renderer-skia-1.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1848,40 +3512,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i18n-embed-fl/i18n-embed-fl-0.7.0.crate",
-        "sha256": "9fc1f8715195dffc4caddcf1cf3128da15fe5d8a137606ea8856c9300047d5a2",
-        "dest": "cargo/vendor/i18n-embed-fl-0.7.0"
+        "url": "https://static.crates.io/crates/i18n-embed-fl/i18n-embed-fl-0.8.0.crate",
+        "sha256": "8241a781f49e923415e106fcd1f89c3fab92cc9f699a521c56e95dee273903d3",
+        "dest": "cargo/vendor/i18n-embed-fl-0.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9fc1f8715195dffc4caddcf1cf3128da15fe5d8a137606ea8856c9300047d5a2\", \"files\": {}}",
-        "dest": "cargo/vendor/i18n-embed-fl-0.7.0",
+        "contents": "{\"package\": \"8241a781f49e923415e106fcd1f89c3fab92cc9f699a521c56e95dee273903d3\", \"files\": {}}",
+        "dest": "cargo/vendor/i18n-embed-fl-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/i18n-embed-impl/i18n-embed-impl-0.8.2.crate",
-        "sha256": "a2a4d5bff745c9a6e1459c490059281b353a4ab0a4e1e58b3eeeaef71f97d07b",
-        "dest": "cargo/vendor/i18n-embed-impl-0.8.2"
+        "url": "https://static.crates.io/crates/i18n-embed-impl/i18n-embed-impl-0.8.3.crate",
+        "sha256": "81093c4701672f59416582fe3145676126fd23ba5db910acad0793c1108aaa58",
+        "dest": "cargo/vendor/i18n-embed-impl-0.8.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a2a4d5bff745c9a6e1459c490059281b353a4ab0a4e1e58b3eeeaef71f97d07b\", \"files\": {}}",
-        "dest": "cargo/vendor/i18n-embed-impl-0.8.2",
+        "contents": "{\"package\": \"81093c4701672f59416582fe3145676126fd23ba5db910acad0793c1108aaa58\", \"files\": {}}",
+        "dest": "cargo/vendor/i18n-embed-impl-0.8.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.57.crate",
-        "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
-        "dest": "cargo/vendor/iana-time-zone-0.1.57"
+        "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.60.crate",
+        "sha256": "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141",
+        "dest": "cargo/vendor/iana-time-zone-0.1.60"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613\", \"files\": {}}",
-        "dest": "cargo/vendor/iana-time-zone-0.1.57",
+        "contents": "{\"package\": \"e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141\", \"files\": {}}",
+        "dest": "cargo/vendor/iana-time-zone-0.1.60",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1900,6 +3564,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icrate/icrate-0.0.4.crate",
+        "sha256": "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319",
+        "dest": "cargo/vendor/icrate-0.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319\", \"files\": {}}",
+        "dest": "cargo/vendor/icrate-0.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ident_case/ident_case-1.0.1.crate",
         "sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39",
         "dest": "cargo/vendor/ident_case-1.0.1"
@@ -1913,27 +3590,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/idna/idna-0.4.0.crate",
-        "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
-        "dest": "cargo/vendor/idna-0.4.0"
+        "url": "https://static.crates.io/crates/idna/idna-0.5.0.crate",
+        "sha256": "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6",
+        "dest": "cargo/vendor/idna-0.5.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c\", \"files\": {}}",
-        "dest": "cargo/vendor/idna-0.4.0",
+        "contents": "{\"package\": \"634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6\", \"files\": {}}",
+        "dest": "cargo/vendor/idna-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/image/image-0.24.7.crate",
-        "sha256": "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711",
-        "dest": "cargo/vendor/image-0.24.7"
+        "url": "https://static.crates.io/crates/image/image-0.24.8.crate",
+        "sha256": "034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23",
+        "dest": "cargo/vendor/image-0.24.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711\", \"files\": {}}",
-        "dest": "cargo/vendor/image-0.24.7",
+        "contents": "{\"package\": \"034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23\", \"files\": {}}",
+        "dest": "cargo/vendor/image-0.24.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1965,6 +3642,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/imagesize/imagesize-0.12.0.crate",
+        "sha256": "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284",
+        "dest": "cargo/vendor/imagesize-0.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284\", \"files\": {}}",
+        "dest": "cargo/vendor/imagesize-0.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/imgref/imgref-1.10.1.crate",
+        "sha256": "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126",
+        "dest": "cargo/vendor/imgref-1.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126\", \"files\": {}}",
+        "dest": "cargo/vendor/imgref-1.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/indexmap/indexmap-1.9.3.crate",
         "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
         "dest": "cargo/vendor/indexmap-1.9.3"
@@ -1978,14 +3681,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/indexmap/indexmap-2.0.2.crate",
-        "sha256": "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897",
-        "dest": "cargo/vendor/indexmap-2.0.2"
+        "url": "https://static.crates.io/crates/indexmap/indexmap-2.2.3.crate",
+        "sha256": "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177",
+        "dest": "cargo/vendor/indexmap-2.2.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897\", \"files\": {}}",
-        "dest": "cargo/vendor/indexmap-2.0.2",
+        "contents": "{\"package\": \"233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-2.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indicatif/indicatif-0.17.8.crate",
+        "sha256": "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3",
+        "dest": "cargo/vendor/indicatif-0.17.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3\", \"files\": {}}",
+        "dest": "cargo/vendor/indicatif-0.17.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2004,19 +3720,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/inflate/inflate-0.4.5.crate",
-        "sha256": "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff",
-        "dest": "cargo/vendor/inflate-0.4.5"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff\", \"files\": {}}",
-        "dest": "cargo/vendor/inflate-0.4.5",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/inout/inout-0.1.3.crate",
         "sha256": "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5",
         "dest": "cargo/vendor/inout-0.1.3"
@@ -2025,6 +3728,58 @@
         "type": "inline",
         "contents": "{\"package\": \"a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5\", \"files\": {}}",
         "dest": "cargo/vendor/inout-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/input/input-0.8.3.crate",
+        "sha256": "e6e74cd82cedcd66db78742a8337bdc48f188c4d2c12742cbc5cd85113f0b059",
+        "dest": "cargo/vendor/input-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6e74cd82cedcd66db78742a8337bdc48f188c4d2c12742cbc5cd85113f0b059\", \"files\": {}}",
+        "dest": "cargo/vendor/input-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/input-sys/input-sys-1.18.0.crate",
+        "sha256": "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0",
+        "dest": "cargo/vendor/input-sys-1.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0\", \"files\": {}}",
+        "dest": "cargo/vendor/input-sys-1.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/instant/instant-0.1.12.crate",
+        "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
+        "dest": "cargo/vendor/instant-0.1.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c\", \"files\": {}}",
+        "dest": "cargo/vendor/instant-0.1.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/integer-sqrt/integer-sqrt-0.1.5.crate",
+        "sha256": "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770",
+        "dest": "cargo/vendor/integer-sqrt-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770\", \"files\": {}}",
+        "dest": "cargo/vendor/integer-sqrt-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2051,6 +3806,19 @@
         "type": "inline",
         "contents": "{\"package\": \"078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972\", \"files\": {}}",
         "dest": "cargo/vendor/intl_pluralrules-7.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/io-lifetimes/io-lifetimes-1.0.11.crate",
+        "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+        "dest": "cargo/vendor/io-lifetimes-1.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2\", \"files\": {}}",
+        "dest": "cargo/vendor/io-lifetimes-1.0.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2108,40 +3876,131 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/itoa/itoa-1.0.9.crate",
-        "sha256": "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38",
-        "dest": "cargo/vendor/itoa-1.0.9"
+        "url": "https://static.crates.io/crates/itertools/itertools-0.12.1.crate",
+        "sha256": "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569",
+        "dest": "cargo/vendor/itertools-0.12.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38\", \"files\": {}}",
-        "dest": "cargo/vendor/itoa-1.0.9",
+        "contents": "{\"package\": \"ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569\", \"files\": {}}",
+        "dest": "cargo/vendor/itertools-0.12.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/jpeg-decoder/jpeg-decoder-0.3.0.crate",
-        "sha256": "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e",
-        "dest": "cargo/vendor/jpeg-decoder-0.3.0"
+        "url": "https://static.crates.io/crates/itoa/itoa-1.0.10.crate",
+        "sha256": "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c",
+        "dest": "cargo/vendor/itoa-1.0.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e\", \"files\": {}}",
-        "dest": "cargo/vendor/jpeg-decoder-0.3.0",
+        "contents": "{\"package\": \"b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c\", \"files\": {}}",
+        "dest": "cargo/vendor/itoa-1.0.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.64.crate",
-        "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
-        "dest": "cargo/vendor/js-sys-0.3.64"
+        "url": "https://static.crates.io/crates/jni/jni-0.21.1.crate",
+        "sha256": "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97",
+        "dest": "cargo/vendor/jni-0.21.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a\", \"files\": {}}",
-        "dest": "cargo/vendor/js-sys-0.3.64",
+        "contents": "{\"package\": \"1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-0.21.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-sys/jni-sys-0.3.0.crate",
+        "sha256": "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130",
+        "dest": "cargo/vendor/jni-sys-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-sys-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jobserver/jobserver-0.1.28.crate",
+        "sha256": "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6",
+        "dest": "cargo/vendor/jobserver-0.1.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6\", \"files\": {}}",
+        "dest": "cargo/vendor/jobserver-0.1.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jpeg-decoder/jpeg-decoder-0.3.1.crate",
+        "sha256": "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0",
+        "dest": "cargo/vendor/jpeg-decoder-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0\", \"files\": {}}",
+        "dest": "cargo/vendor/jpeg-decoder-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.68.crate",
+        "sha256": "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee",
+        "dest": "cargo/vendor/js-sys-0.3.68"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee\", \"files\": {}}",
+        "dest": "cargo/vendor/js-sys-0.3.68",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/khronos_api/khronos_api-3.1.0.crate",
+        "sha256": "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc",
+        "dest": "cargo/vendor/khronos_api-3.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc\", \"files\": {}}",
+        "dest": "cargo/vendor/khronos_api-3.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/kurbo/kurbo-0.9.5.crate",
+        "sha256": "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b",
+        "dest": "cargo/vendor/kurbo-0.9.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b\", \"files\": {}}",
+        "dest": "cargo/vendor/kurbo-0.9.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lazy-bytes-cast/lazy-bytes-cast-5.0.1.crate",
+        "sha256": "10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b",
+        "dest": "cargo/vendor/lazy-bytes-cast-5.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b\", \"files\": {}}",
+        "dest": "cargo/vendor/lazy-bytes-cast-5.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2160,6 +4019,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lazycell/lazycell-1.3.0.crate",
+        "sha256": "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55",
+        "dest": "cargo/vendor/lazycell-1.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55\", \"files\": {}}",
+        "dest": "cargo/vendor/lazycell-1.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/lebe/lebe-0.5.2.crate",
         "sha256": "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8",
         "dest": "cargo/vendor/lebe-0.5.2"
@@ -2173,14 +4045,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libc/libc-0.2.149.crate",
-        "sha256": "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b",
-        "dest": "cargo/vendor/libc-0.2.149"
+        "url": "https://static.crates.io/crates/libc/libc-0.2.153.crate",
+        "sha256": "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd",
+        "dest": "cargo/vendor/libc-0.2.153"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b\", \"files\": {}}",
-        "dest": "cargo/vendor/libc-0.2.149",
+        "contents": "{\"package\": \"9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.153",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libflate/libflate-2.0.0.crate",
+        "sha256": "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf",
+        "dest": "cargo/vendor/libflate-2.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf\", \"files\": {}}",
+        "dest": "cargo/vendor/libflate-2.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libflate_lz77/libflate_lz77-2.0.0.crate",
+        "sha256": "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524",
+        "dest": "cargo/vendor/libflate_lz77-2.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524\", \"files\": {}}",
+        "dest": "cargo/vendor/libflate_lz77-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2212,6 +4110,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libloading/libloading-0.7.4.crate",
+        "sha256": "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f",
+        "dest": "cargo/vendor/libloading-0.7.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.7.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libloading/libloading-0.8.1.crate",
+        "sha256": "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161",
+        "dest": "cargo/vendor/libloading-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libm/libm-0.2.8.crate",
         "sha256": "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058",
         "dest": "cargo/vendor/libm-0.2.8"
@@ -2220,6 +4144,71 @@
         "type": "inline",
         "contents": "{\"package\": \"4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058\", \"files\": {}}",
         "dest": "cargo/vendor/libm-0.2.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libraw-rs/libraw-rs-0.0.4.crate",
+        "sha256": "24ec60aab878560c299c6e70a0c6dc2278a2159ac6fe09650917266b8985387f",
+        "dest": "cargo/vendor/libraw-rs-0.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"24ec60aab878560c299c6e70a0c6dc2278a2159ac6fe09650917266b8985387f\", \"files\": {}}",
+        "dest": "cargo/vendor/libraw-rs-0.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libraw-rs-sys/libraw-rs-sys-0.0.4+libraw-0.20.1.crate",
+        "sha256": "ba094a3b8b04cc42fdeafaff06f81d3b13a7d01cc7a8eae55b943dae1b65c3cc",
+        "dest": "cargo/vendor/libraw-rs-sys-0.0.4+libraw-0.20.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ba094a3b8b04cc42fdeafaff06f81d3b13a7d01cc7a8eae55b943dae1b65c3cc\", \"files\": {}}",
+        "dest": "cargo/vendor/libraw-rs-sys-0.0.4+libraw-0.20.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libredox/libredox-0.0.1.crate",
+        "sha256": "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8",
+        "dest": "cargo/vendor/libredox-0.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8\", \"files\": {}}",
+        "dest": "cargo/vendor/libredox-0.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libredox/libredox-0.0.2.crate",
+        "sha256": "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607",
+        "dest": "cargo/vendor/libredox-0.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607\", \"files\": {}}",
+        "dest": "cargo/vendor/libredox-0.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libudev-sys/libudev-sys-0.1.4.crate",
+        "sha256": "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324",
+        "dest": "cargo/vendor/libudev-sys-0.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324\", \"files\": {}}",
+        "dest": "cargo/vendor/libudev-sys-0.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2238,14 +4227,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.10.crate",
-        "sha256": "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.10"
+        "url": "https://static.crates.io/crates/linked_hash_set/linked_hash_set-0.1.4.crate",
+        "sha256": "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588",
+        "dest": "cargo/vendor/linked_hash_set-0.1.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f\", \"files\": {}}",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.10",
+        "contents": "{\"package\": \"47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588\", \"files\": {}}",
+        "dest": "cargo/vendor/linked_hash_set-0.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.3.8.crate",
+        "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+        "dest": "cargo/vendor/linux-raw-sys-0.3.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.3.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.13.crate",
+        "sha256": "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c",
+        "dest": "cargo/vendor/linux-raw-sys-0.4.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.4.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.6.4.crate",
+        "sha256": "f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4",
+        "dest": "cargo/vendor/linux-raw-sys-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.6.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2264,27 +4292,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.10.crate",
-        "sha256": "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16",
-        "dest": "cargo/vendor/lock_api-0.4.10"
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.11.crate",
+        "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
+        "dest": "cargo/vendor/lock_api-0.4.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16\", \"files\": {}}",
-        "dest": "cargo/vendor/lock_api-0.4.10",
+        "contents": "{\"package\": \"3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45\", \"files\": {}}",
+        "dest": "cargo/vendor/lock_api-0.4.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lofty/lofty-0.16.0.crate",
-        "sha256": "cfa7a62ede7d634892901a2be8bb32f3e13d0418f276d2a391a509afe050f01b",
-        "dest": "cargo/vendor/lofty-0.16.0"
+        "url": "https://static.crates.io/crates/lofty/lofty-0.18.2.crate",
+        "sha256": "f75066eb1d25a7047fb2667edb410ae2592439ed81546f95c28b0a1c7d7d3818",
+        "dest": "cargo/vendor/lofty-0.18.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cfa7a62ede7d634892901a2be8bb32f3e13d0418f276d2a391a509afe050f01b\", \"files\": {}}",
-        "dest": "cargo/vendor/lofty-0.16.0",
+        "contents": "{\"package\": \"f75066eb1d25a7047fb2667edb410ae2592439ed81546f95c28b0a1c7d7d3818\", \"files\": {}}",
+        "dest": "cargo/vendor/lofty-0.18.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2329,6 +4357,71 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lru/lru-0.12.2.crate",
+        "sha256": "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22",
+        "dest": "cargo/vendor/lru-0.12.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22\", \"files\": {}}",
+        "dest": "cargo/vendor/lru-0.12.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lyon_algorithms/lyon_algorithms-1.0.4.crate",
+        "sha256": "a3bca95f9a4955b3e4a821fbbcd5edfbd9be2a9a50bb5758173e5358bfb4c623",
+        "dest": "cargo/vendor/lyon_algorithms-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a3bca95f9a4955b3e4a821fbbcd5edfbd9be2a9a50bb5758173e5358bfb4c623\", \"files\": {}}",
+        "dest": "cargo/vendor/lyon_algorithms-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lyon_extra/lyon_extra-1.0.1.crate",
+        "sha256": "b9ce2ae38f2480094ec1f0d5df51a75581fa84f0e8f32a0edb1d264630c99f3b",
+        "dest": "cargo/vendor/lyon_extra-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b9ce2ae38f2480094ec1f0d5df51a75581fa84f0e8f32a0edb1d264630c99f3b\", \"files\": {}}",
+        "dest": "cargo/vendor/lyon_extra-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lyon_geom/lyon_geom-1.0.5.crate",
+        "sha256": "edecfb8d234a2b0be031ab02ebcdd9f3b9ee418fb35e265f7a540a48d197bff9",
+        "dest": "cargo/vendor/lyon_geom-1.0.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"edecfb8d234a2b0be031ab02ebcdd9f3b9ee418fb35e265f7a540a48d197bff9\", \"files\": {}}",
+        "dest": "cargo/vendor/lyon_geom-1.0.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lyon_path/lyon_path-1.0.4.crate",
+        "sha256": "ca507745ba7ccbc76e5c44e7b63b1a29d2b0d6126f375806a5bbaf657c7d6c45",
+        "dest": "cargo/vendor/lyon_path-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca507745ba7ccbc76e5c44e7b63b1a29d2b0d6126f375806a5bbaf657c7d6c45\", \"files\": {}}",
+        "dest": "cargo/vendor/lyon_path-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/malloc_buf/malloc_buf-0.0.6.crate",
         "sha256": "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb",
         "dest": "cargo/vendor/malloc_buf-0.0.6"
@@ -2368,14 +4461,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memchr/memchr-2.6.4.crate",
-        "sha256": "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167",
-        "dest": "cargo/vendor/memchr-2.6.4"
+        "url": "https://static.crates.io/crates/memchr/memchr-2.7.1.crate",
+        "sha256": "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149",
+        "dest": "cargo/vendor/memchr-2.7.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167\", \"files\": {}}",
-        "dest": "cargo/vendor/memchr-2.6.4",
+        "contents": "{\"package\": \"523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149\", \"files\": {}}",
+        "dest": "cargo/vendor/memchr-2.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.8.0.crate",
+        "sha256": "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed",
+        "dest": "cargo/vendor/memmap2-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.9.4.crate",
+        "sha256": "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322",
+        "dest": "cargo/vendor/memmap2-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memoffset/memoffset-0.7.1.crate",
+        "sha256": "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4",
+        "dest": "cargo/vendor/memoffset-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4\", \"files\": {}}",
+        "dest": "cargo/vendor/memoffset-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2389,6 +4521,19 @@
         "type": "inline",
         "contents": "{\"package\": \"5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c\", \"files\": {}}",
         "dest": "cargo/vendor/memoffset-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/metal/metal-0.27.0.crate",
+        "sha256": "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25",
+        "dest": "cargo/vendor/metal-0.27.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25\", \"files\": {}}",
+        "dest": "cargo/vendor/metal-0.27.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2420,14 +4565,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.7.1.crate",
-        "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
-        "dest": "cargo/vendor/miniz_oxide-0.7.1"
+        "url": "https://static.crates.io/crates/minimal-lexical/minimal-lexical-0.2.1.crate",
+        "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7\", \"files\": {}}",
-        "dest": "cargo/vendor/miniz_oxide-0.7.1",
+        "contents": "{\"package\": \"68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a\", \"files\": {}}",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.7.2.crate",
+        "sha256": "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7",
+        "dest": "cargo/vendor/miniz_oxide-0.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2441,6 +4599,84 @@
         "type": "inline",
         "contents": "{\"package\": \"5086074c0a0812980aa88703d1bbcb4433e8423ecf4098a9849934f3dc09ba72\", \"files\": {}}",
         "dest": "cargo/vendor/multicache-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk/ndk-0.8.0.crate",
+        "sha256": "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7",
+        "dest": "cargo/vendor/ndk-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk-context/ndk-context-0.1.1.crate",
+        "sha256": "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b",
+        "dest": "cargo/vendor/ndk-context-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-context-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk-sys/ndk-sys-0.5.0+25.2.9519653.crate",
+        "sha256": "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691",
+        "dest": "cargo/vendor/ndk-sys-0.5.0+25.2.9519653"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-sys-0.5.0+25.2.9519653",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nix/nix-0.26.4.crate",
+        "sha256": "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b",
+        "dest": "cargo/vendor/nix-0.26.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b\", \"files\": {}}",
+        "dest": "cargo/vendor/nix-0.26.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nix/nix-0.27.1.crate",
+        "sha256": "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053",
+        "dest": "cargo/vendor/nix-0.27.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053\", \"files\": {}}",
+        "dest": "cargo/vendor/nix-0.27.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nom/nom-7.1.3.crate",
+        "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
+        "dest": "cargo/vendor/nom-7.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a\", \"files\": {}}",
+        "dest": "cargo/vendor/nom-7.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2472,66 +4708,105 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.4.crate",
-        "sha256": "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214",
-        "dest": "cargo/vendor/num-complex-0.4.4"
+        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.5.crate",
+        "sha256": "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6",
+        "dest": "cargo/vendor/num-complex-0.4.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214\", \"files\": {}}",
-        "dest": "cargo/vendor/num-complex-0.4.4",
+        "contents": "{\"package\": \"23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6\", \"files\": {}}",
+        "dest": "cargo/vendor/num-complex-0.4.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.45.crate",
-        "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
-        "dest": "cargo/vendor/num-integer-0.1.45"
+        "url": "https://static.crates.io/crates/num-conv/num-conv-0.1.0.crate",
+        "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
+        "dest": "cargo/vendor/num-conv-0.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9\", \"files\": {}}",
-        "dest": "cargo/vendor/num-integer-0.1.45",
+        "contents": "{\"package\": \"51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9\", \"files\": {}}",
+        "dest": "cargo/vendor/num-conv-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-rational/num-rational-0.4.1.crate",
-        "sha256": "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0",
-        "dest": "cargo/vendor/num-rational-0.4.1"
+        "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.46.crate",
+        "sha256": "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f",
+        "dest": "cargo/vendor/num-integer-0.1.46"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0\", \"files\": {}}",
-        "dest": "cargo/vendor/num-rational-0.4.1",
+        "contents": "{\"package\": \"7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f\", \"files\": {}}",
+        "dest": "cargo/vendor/num-integer-0.1.46",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.17.crate",
-        "sha256": "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c",
-        "dest": "cargo/vendor/num-traits-0.2.17"
+        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.18.crate",
+        "sha256": "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a",
+        "dest": "cargo/vendor/num-traits-0.2.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c\", \"files\": {}}",
-        "dest": "cargo/vendor/num-traits-0.2.17",
+        "contents": "{\"package\": \"da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a\", \"files\": {}}",
+        "dest": "cargo/vendor/num-traits-0.2.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/num_threads/num_threads-0.1.6.crate",
-        "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
-        "dest": "cargo/vendor/num_threads-0.1.6"
+        "url": "https://static.crates.io/crates/num_enum/num_enum-0.7.2.crate",
+        "sha256": "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845",
+        "dest": "cargo/vendor/num_enum-0.7.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44\", \"files\": {}}",
-        "dest": "cargo/vendor/num_threads-0.1.6",
+        "contents": "{\"package\": \"02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum-0.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.7.2.crate",
+        "sha256": "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b",
+        "dest": "cargo/vendor/num_enum_derive-0.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum_derive-0.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_threads/num_threads-0.1.7.crate",
+        "sha256": "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9",
+        "dest": "cargo/vendor/num_threads-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9\", \"files\": {}}",
+        "dest": "cargo/vendor/num_threads-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/number_prefix/number_prefix-0.4.0.crate",
+        "sha256": "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3",
+        "dest": "cargo/vendor/number_prefix-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3\", \"files\": {}}",
+        "dest": "cargo/vendor/number_prefix-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2563,6 +4838,58 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc-sys/objc-sys-0.3.2.crate",
+        "sha256": "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459",
+        "dest": "cargo/vendor/objc-sys-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459\", \"files\": {}}",
+        "dest": "cargo/vendor/objc-sys-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2/objc2-0.4.1.crate",
+        "sha256": "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d",
+        "dest": "cargo/vendor/objc2-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-encode/objc2-encode-3.0.0.crate",
+        "sha256": "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666",
+        "dest": "cargo/vendor/objc2-encode-3.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-encode-3.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc_exception/objc_exception-0.1.2.crate",
+        "sha256": "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4",
+        "dest": "cargo/vendor/objc_exception-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4\", \"files\": {}}",
+        "dest": "cargo/vendor/objc_exception-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/objc_id/objc_id-0.1.1.crate",
         "sha256": "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b",
         "dest": "cargo/vendor/objc_id-0.1.1"
@@ -2576,40 +4903,79 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ogg_pager/ogg_pager-0.5.0.crate",
-        "sha256": "0d218a406e5de88e1c492d0162d569916f7436efe851ba5cc40a4bf4fa97cb40",
-        "dest": "cargo/vendor/ogg_pager-0.5.0"
+        "url": "https://static.crates.io/crates/ogg_pager/ogg_pager-0.6.0.crate",
+        "sha256": "c949d63b387b25c332f6e39d1762dd4b405008289dd7681f02c258b1294653ca",
+        "dest": "cargo/vendor/ogg_pager-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0d218a406e5de88e1c492d0162d569916f7436efe851ba5cc40a4bf4fa97cb40\", \"files\": {}}",
-        "dest": "cargo/vendor/ogg_pager-0.5.0",
+        "contents": "{\"package\": \"c949d63b387b25c332f6e39d1762dd4b405008289dd7681f02c258b1294653ca\", \"files\": {}}",
+        "dest": "cargo/vendor/ogg_pager-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/once_cell/once_cell-1.18.0.crate",
-        "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
-        "dest": "cargo/vendor/once_cell-1.18.0"
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.19.0.crate",
+        "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+        "dest": "cargo/vendor/once_cell-1.19.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d\", \"files\": {}}",
-        "dest": "cargo/vendor/once_cell-1.18.0",
+        "contents": "{\"package\": \"3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.19.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/open/open-5.0.0.crate",
-        "sha256": "cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8",
-        "dest": "cargo/vendor/open-5.0.0"
+        "url": "https://static.crates.io/crates/open/open-5.0.1.crate",
+        "sha256": "90878fb664448b54c4e592455ad02831e23a3f7e157374a8b95654731aac7349",
+        "dest": "cargo/vendor/open-5.0.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8\", \"files\": {}}",
-        "dest": "cargo/vendor/open-5.0.0",
+        "contents": "{\"package\": \"90878fb664448b54c4e592455ad02831e23a3f7e157374a8b95654731aac7349\", \"files\": {}}",
+        "dest": "cargo/vendor/open-5.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/orbclient/orbclient-0.3.47.crate",
+        "sha256": "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166",
+        "dest": "cargo/vendor/orbclient-0.3.47"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166\", \"files\": {}}",
+        "dest": "cargo/vendor/orbclient-0.3.47",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ordered-stream/ordered-stream-0.2.0.crate",
+        "sha256": "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50",
+        "dest": "cargo/vendor/ordered-stream-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50\", \"files\": {}}",
+        "dest": "cargo/vendor/ordered-stream-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/os_info/os_info-3.7.0.crate",
+        "sha256": "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e",
+        "dest": "cargo/vendor/os_info-3.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e\", \"files\": {}}",
+        "dest": "cargo/vendor/os_info-3.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2628,27 +4994,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pango/pango-0.18.0.crate",
-        "sha256": "06a9e54b831d033206160096b825f2070cf5fda7e35167b1c01e9e774f9202d1",
-        "dest": "cargo/vendor/pango-0.18.0"
+        "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.20.0.crate",
+        "sha256": "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7",
+        "dest": "cargo/vendor/owned_ttf_parser-0.20.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"06a9e54b831d033206160096b825f2070cf5fda7e35167b1c01e9e774f9202d1\", \"files\": {}}",
-        "dest": "cargo/vendor/pango-0.18.0",
+        "contents": "{\"package\": \"d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7\", \"files\": {}}",
+        "dest": "cargo/vendor/owned_ttf_parser-0.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.18.0.crate",
-        "sha256": "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5",
-        "dest": "cargo/vendor/pango-sys-0.18.0"
+        "url": "https://static.crates.io/crates/pango/pango-0.19.2.crate",
+        "sha256": "7809e8af4df8d024a066106b72ca6bc7253a484ae3867041a96103ef8a13188d",
+        "dest": "cargo/vendor/pango-0.19.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5\", \"files\": {}}",
-        "dest": "cargo/vendor/pango-sys-0.18.0",
+        "contents": "{\"package\": \"7809e8af4df8d024a066106b72ca6bc7253a484ae3867041a96103ef8a13188d\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-0.19.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.19.0.crate",
+        "sha256": "f52ef6a881c19fbfe3b1484df5cad411acaaba29dbec843941c3110d19f340ea",
+        "dest": "cargo/vendor/pango-sys-0.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f52ef6a881c19fbfe3b1484df5cad411acaaba29dbec843941c3110d19f340ea\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-sys-0.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking/parking-2.2.0.crate",
+        "sha256": "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae",
+        "dest": "cargo/vendor/parking-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae\", \"files\": {}}",
+        "dest": "cargo/vendor/parking-2.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2667,14 +5059,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.8.crate",
-        "sha256": "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447",
-        "dest": "cargo/vendor/parking_lot_core-0.9.8"
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.9.crate",
+        "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
+        "dest": "cargo/vendor/parking_lot_core-0.9.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447\", \"files\": {}}",
-        "dest": "cargo/vendor/parking_lot_core-0.9.8",
+        "contents": "{\"package\": \"4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot_core-0.9.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2732,40 +5124,79 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pdf/pdf-0.8.1.crate",
-        "sha256": "e375ec076445f61d4dbc4636e9e788f841d279c65d6fea8a3875caddd4f2dd82",
-        "dest": "cargo/vendor/pdf-0.8.1"
+        "url": "https://static.crates.io/crates/pdf/pdf-0.9.0.crate",
+        "sha256": "3afc7e745846405d572daba57a429f30a198d955602aff8a1a9e437c2abfcaa2",
+        "dest": "cargo/vendor/pdf-0.9.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e375ec076445f61d4dbc4636e9e788f841d279c65d6fea8a3875caddd4f2dd82\", \"files\": {}}",
-        "dest": "cargo/vendor/pdf-0.8.1",
+        "contents": "{\"package\": \"3afc7e745846405d572daba57a429f30a198d955602aff8a1a9e437c2abfcaa2\", \"files\": {}}",
+        "dest": "cargo/vendor/pdf-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pdf_derive/pdf_derive-0.1.22.crate",
-        "sha256": "7f4007262775d0798de87b15cbc64cf1aed5f7ee87eec847e297b69d8ed4b4f8",
-        "dest": "cargo/vendor/pdf_derive-0.1.22"
+        "url": "https://static.crates.io/crates/pdf_derive/pdf_derive-0.2.0.crate",
+        "sha256": "1038b9cb38dec35eeee9f23eacfb2480087982f9b7e9221efa8034eea9ca2360",
+        "dest": "cargo/vendor/pdf_derive-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7f4007262775d0798de87b15cbc64cf1aed5f7ee87eec847e297b69d8ed4b4f8\", \"files\": {}}",
-        "dest": "cargo/vendor/pdf_derive-0.1.22",
+        "contents": "{\"package\": \"1038b9cb38dec35eeee9f23eacfb2480087982f9b7e9221efa8034eea9ca2360\", \"files\": {}}",
+        "dest": "cargo/vendor/pdf_derive-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.3.0.crate",
-        "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
-        "dest": "cargo/vendor/percent-encoding-2.3.0"
+        "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.3.1.crate",
+        "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
+        "dest": "cargo/vendor/percent-encoding-2.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94\", \"files\": {}}",
-        "dest": "cargo/vendor/percent-encoding-2.3.0",
+        "contents": "{\"package\": \"e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e\", \"files\": {}}",
+        "dest": "cargo/vendor/percent-encoding-2.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pico-args/pico-args-0.5.0.crate",
+        "sha256": "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315",
+        "dest": "cargo/vendor/pico-args-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315\", \"files\": {}}",
+        "dest": "cargo/vendor/pico-args-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project/pin-project-1.1.4.crate",
+        "sha256": "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0",
+        "dest": "cargo/vendor/pin-project-1.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-1.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.1.4.crate",
+        "sha256": "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690",
+        "dest": "cargo/vendor/pin-project-internal-1.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-internal-1.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2797,27 +5228,105 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.27.crate",
-        "sha256": "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964",
-        "dest": "cargo/vendor/pkg-config-0.3.27"
+        "url": "https://static.crates.io/crates/pin-weak/pin-weak-1.1.0.crate",
+        "sha256": "b330c9d1b92dfe68442ca20b009c717d5f0b1e3cf4965e62f704c3c6e95a1305",
+        "dest": "cargo/vendor/pin-weak-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964\", \"files\": {}}",
-        "dest": "cargo/vendor/pkg-config-0.3.27",
+        "contents": "{\"package\": \"b330c9d1b92dfe68442ca20b009c717d5f0b1e3cf4965e62f704c3c6e95a1305\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-weak-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/png/png-0.17.10.crate",
-        "sha256": "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64",
-        "dest": "cargo/vendor/png-0.17.10"
+        "url": "https://static.crates.io/crates/piper/piper-0.2.1.crate",
+        "sha256": "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4",
+        "dest": "cargo/vendor/piper-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64\", \"files\": {}}",
-        "dest": "cargo/vendor/png-0.17.10",
+        "contents": "{\"package\": \"668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4\", \"files\": {}}",
+        "dest": "cargo/vendor/piper-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.30.crate",
+        "sha256": "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec",
+        "dest": "cargo/vendor/pkg-config-0.3.30"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec\", \"files\": {}}",
+        "dest": "cargo/vendor/pkg-config-0.3.30",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/png/png-0.17.12.crate",
+        "sha256": "78c2378060fb13acff3ba0325b83442c1d2c44fbb76df481160ddc1687cce160",
+        "dest": "cargo/vendor/png-0.17.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"78c2378060fb13acff3ba0325b83442c1d2c44fbb76df481160ddc1687cce160\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.17.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/polling/polling-2.8.0.crate",
+        "sha256": "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce",
+        "dest": "cargo/vendor/polling-2.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce\", \"files\": {}}",
+        "dest": "cargo/vendor/polling-2.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/polling/polling-3.5.0.crate",
+        "sha256": "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9",
+        "dest": "cargo/vendor/polling-3.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9\", \"files\": {}}",
+        "dest": "cargo/vendor/polling-3.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pollster/pollster-0.3.0.crate",
+        "sha256": "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2",
+        "dest": "cargo/vendor/pollster-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2\", \"files\": {}}",
+        "dest": "cargo/vendor/pollster-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/portable-atomic/portable-atomic-1.6.0.crate",
+        "sha256": "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0",
+        "dest": "cargo/vendor/portable-atomic-1.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0\", \"files\": {}}",
+        "dest": "cargo/vendor/portable-atomic-1.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2849,6 +5358,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.16.crate",
+        "sha256": "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5",
+        "dest": "cargo/vendor/prettyplease-0.2.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5\", \"files\": {}}",
+        "dest": "cargo/vendor/prettyplease-0.2.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/primal-check/primal-check-0.3.3.crate",
         "sha256": "9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0",
         "dest": "cargo/vendor/primal-check-0.3.3"
@@ -2870,6 +5392,19 @@
         "type": "inline",
         "contents": "{\"package\": \"7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919\", \"files\": {}}",
         "dest": "cargo/vendor/proc-macro-crate-1.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.1.0.crate",
+        "sha256": "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284",
+        "dest": "cargo/vendor/proc-macro-crate-3.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-3.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2901,14 +5436,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.69.crate",
-        "sha256": "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da",
-        "dest": "cargo/vendor/proc-macro2-1.0.69"
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.78.crate",
+        "sha256": "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae",
+        "dest": "cargo/vendor/proc-macro2-1.0.78"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro2-1.0.69",
+        "contents": "{\"package\": \"e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.78",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2927,14 +5462,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quote/quote-1.0.33.crate",
-        "sha256": "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae",
-        "dest": "cargo/vendor/quote-1.0.33"
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.31.0.crate",
+        "sha256": "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33",
+        "dest": "cargo/vendor/quick-xml-0.31.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae\", \"files\": {}}",
-        "dest": "cargo/vendor/quote-1.0.33",
+        "contents": "{\"package\": \"1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-xml-0.31.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quote/quote-1.0.35.crate",
+        "sha256": "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef",
+        "dest": "cargo/vendor/quote-1.0.35"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.35",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2979,6 +5527,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.5.2.crate",
+        "sha256": "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9",
+        "dest": "cargo/vendor/raw-window-handle-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-window-handle-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rawloader/rawloader-0.37.1.crate",
         "sha256": "4d8c6f168c492ffd326537b3aa5a8d5fe07f0d8a3970c5957f286bcd13f888aa",
         "dest": "cargo/vendor/rawloader-0.37.1"
@@ -2992,27 +5553,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rayon/rayon-1.8.0.crate",
-        "sha256": "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1",
-        "dest": "cargo/vendor/rayon-1.8.0"
+        "url": "https://static.crates.io/crates/rayon/rayon-1.8.1.crate",
+        "sha256": "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051",
+        "dest": "cargo/vendor/rayon-1.8.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1\", \"files\": {}}",
-        "dest": "cargo/vendor/rayon-1.8.0",
+        "contents": "{\"package\": \"fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-1.8.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rayon-core/rayon-core-1.12.0.crate",
-        "sha256": "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed",
-        "dest": "cargo/vendor/rayon-core-1.12.0"
+        "url": "https://static.crates.io/crates/rayon-core/rayon-core-1.12.1.crate",
+        "sha256": "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2",
+        "dest": "cargo/vendor/rayon-core-1.12.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed\", \"files\": {}}",
-        "dest": "cargo/vendor/rayon-core-1.12.0",
+        "contents": "{\"package\": \"1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-core-1.12.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3031,19 +5592,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.2.16.crate",
-        "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a",
-        "dest": "cargo/vendor/redox_syscall-0.2.16"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a\", \"files\": {}}",
-        "dest": "cargo/vendor/redox_syscall-0.2.16",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.3.5.crate",
         "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
         "dest": "cargo/vendor/redox_syscall-0.3.5"
@@ -3057,27 +5605,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.3.crate",
-        "sha256": "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b",
-        "dest": "cargo/vendor/redox_users-0.4.3"
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.4.1.crate",
+        "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa",
+        "dest": "cargo/vendor/redox_syscall-0.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b\", \"files\": {}}",
-        "dest": "cargo/vendor/redox_users-0.4.3",
+        "contents": "{\"package\": \"4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex/regex-1.10.0.crate",
-        "sha256": "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87",
-        "dest": "cargo/vendor/regex-1.10.0"
+        "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.4.crate",
+        "sha256": "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4",
+        "dest": "cargo/vendor/redox_users-0.4.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-1.10.0",
+        "contents": "{\"package\": \"a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_users-0.4.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex/regex-1.10.3.crate",
+        "sha256": "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15",
+        "dest": "cargo/vendor/regex-1.10.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-1.10.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3096,14 +5657,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.1.crate",
-        "sha256": "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b",
-        "dest": "cargo/vendor/regex-automata-0.4.1"
+        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.5.crate",
+        "sha256": "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd",
+        "dest": "cargo/vendor/regex-automata-0.4.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-automata-0.4.1",
+        "contents": "{\"package\": \"5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-automata-0.4.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3122,66 +5683,144 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.1.crate",
-        "sha256": "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33",
-        "dest": "cargo/vendor/regex-syntax-0.8.1"
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.2.crate",
+        "sha256": "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f",
+        "dest": "cargo/vendor/regex-syntax-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-syntax-0.8.1",
+        "contents": "{\"package\": \"c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-syntax-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rubato/rubato-0.12.0.crate",
-        "sha256": "cd70209c27d5b08f5528bdc779ea3ffb418954e28987f9f9775c6eac41003f9c",
-        "dest": "cargo/vendor/rubato-0.12.0"
+        "url": "https://static.crates.io/crates/resvg/resvg-0.38.0.crate",
+        "sha256": "5c34501046959e06470ba62a2dc7f31c15f94ac250d842a45f9e012f4ee40c1e",
+        "dest": "cargo/vendor/resvg-0.38.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cd70209c27d5b08f5528bdc779ea3ffb418954e28987f9f9775c6eac41003f9c\", \"files\": {}}",
-        "dest": "cargo/vendor/rubato-0.12.0",
+        "contents": "{\"package\": \"5c34501046959e06470ba62a2dc7f31c15f94ac250d842a45f9e012f4ee40c1e\", \"files\": {}}",
+        "dest": "cargo/vendor/resvg-0.38.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rust-embed/rust-embed-8.0.0.crate",
-        "sha256": "b1e7d90385b59f0a6bf3d3b757f3ca4ece2048265d70db20a2016043d4509a40",
-        "dest": "cargo/vendor/rust-embed-8.0.0"
+        "url": "https://static.crates.io/crates/rfd/rfd-0.13.0.crate",
+        "sha256": "c0d8ab342bcc5436e04d3a4c1e09e17d74958bfaddf8d5fad6f85607df0f994f",
+        "dest": "cargo/vendor/rfd-0.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b1e7d90385b59f0a6bf3d3b757f3ca4ece2048265d70db20a2016043d4509a40\", \"files\": {}}",
-        "dest": "cargo/vendor/rust-embed-8.0.0",
+        "contents": "{\"package\": \"c0d8ab342bcc5436e04d3a4c1e09e17d74958bfaddf8d5fad6f85607df0f994f\", \"files\": {}}",
+        "dest": "cargo/vendor/rfd-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rust-embed-impl/rust-embed-impl-8.0.0.crate",
-        "sha256": "3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29",
-        "dest": "cargo/vendor/rust-embed-impl-8.0.0"
+        "url": "https://static.crates.io/crates/rgb/rgb-0.8.37.crate",
+        "sha256": "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8",
+        "dest": "cargo/vendor/rgb-0.8.37"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29\", \"files\": {}}",
-        "dest": "cargo/vendor/rust-embed-impl-8.0.0",
+        "contents": "{\"package\": \"05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8\", \"files\": {}}",
+        "dest": "cargo/vendor/rgb-0.8.37",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rust-embed-utils/rust-embed-utils-8.0.0.crate",
-        "sha256": "873feff8cb7bf86fdf0a71bb21c95159f4e4a37dd7a4bd1855a940909b583ada",
-        "dest": "cargo/vendor/rust-embed-utils-8.0.0"
+        "url": "https://static.crates.io/crates/rle-decode-fast/rle-decode-fast-1.0.3.crate",
+        "sha256": "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422",
+        "dest": "cargo/vendor/rle-decode-fast-1.0.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"873feff8cb7bf86fdf0a71bb21c95159f4e4a37dd7a4bd1855a940909b583ada\", \"files\": {}}",
-        "dest": "cargo/vendor/rust-embed-utils-8.0.0",
+        "contents": "{\"package\": \"3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422\", \"files\": {}}",
+        "dest": "cargo/vendor/rle-decode-fast-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rowan/rowan-0.15.15.crate",
+        "sha256": "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49",
+        "dest": "cargo/vendor/rowan-0.15.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49\", \"files\": {}}",
+        "dest": "cargo/vendor/rowan-0.15.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/roxmltree/roxmltree-0.19.0.crate",
+        "sha256": "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f",
+        "dest": "cargo/vendor/roxmltree-0.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f\", \"files\": {}}",
+        "dest": "cargo/vendor/roxmltree-0.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rubato/rubato-0.14.1.crate",
+        "sha256": "e6dd52e80cfc21894deadf554a5673002938ae4625f7a283e536f9cf7c17b0d5",
+        "dest": "cargo/vendor/rubato-0.14.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6dd52e80cfc21894deadf554a5673002938ae4625f7a283e536f9cf7c17b0d5\", \"files\": {}}",
+        "dest": "cargo/vendor/rubato-0.14.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rust-embed/rust-embed-8.2.0.crate",
+        "sha256": "a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f",
+        "dest": "cargo/vendor/rust-embed-8.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f\", \"files\": {}}",
+        "dest": "cargo/vendor/rust-embed-8.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rust-embed-impl/rust-embed-impl-8.2.0.crate",
+        "sha256": "6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16",
+        "dest": "cargo/vendor/rust-embed-impl-8.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16\", \"files\": {}}",
+        "dest": "cargo/vendor/rust-embed-impl-8.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rust-embed-utils/rust-embed-utils-8.2.0.crate",
+        "sha256": "8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665",
+        "dest": "cargo/vendor/rust-embed-utils-8.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665\", \"files\": {}}",
+        "dest": "cargo/vendor/rust-embed-utils-8.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3252,27 +5891,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustfft/rustfft-6.1.0.crate",
-        "sha256": "e17d4f6cbdb180c9f4b2a26bbf01c4e647f1e1dea22fe8eb9db54198b32f9434",
-        "dest": "cargo/vendor/rustfft-6.1.0"
+        "url": "https://static.crates.io/crates/rustfft/rustfft-6.2.0.crate",
+        "sha256": "43806561bc506d0c5d160643ad742e3161049ac01027b5e6d7524091fd401d86",
+        "dest": "cargo/vendor/rustfft-6.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e17d4f6cbdb180c9f4b2a26bbf01c4e647f1e1dea22fe8eb9db54198b32f9434\", \"files\": {}}",
-        "dest": "cargo/vendor/rustfft-6.1.0",
+        "contents": "{\"package\": \"43806561bc506d0c5d160643ad742e3161049ac01027b5e6d7524091fd401d86\", \"files\": {}}",
+        "dest": "cargo/vendor/rustfft-6.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustix/rustix-0.38.19.crate",
-        "sha256": "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed",
-        "dest": "cargo/vendor/rustix-0.38.19"
+        "url": "https://static.crates.io/crates/rustix/rustix-0.37.27.crate",
+        "sha256": "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2",
+        "dest": "cargo/vendor/rustix-0.37.27"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed\", \"files\": {}}",
-        "dest": "cargo/vendor/rustix-0.38.19",
+        "contents": "{\"package\": \"fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-0.37.27",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustix/rustix-0.38.31.crate",
+        "sha256": "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949",
+        "dest": "cargo/vendor/rustix-0.38.31"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-0.38.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3291,27 +5943,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rusty-chromaprint/rusty-chromaprint-0.1.3.crate",
-        "sha256": "023a224821c3208db13134f398c2d92ed81267ef4f65ac8dff670c00b829faac",
-        "dest": "cargo/vendor/rusty-chromaprint-0.1.3"
+        "url": "https://static.crates.io/crates/rusty-chromaprint/rusty-chromaprint-0.2.0.crate",
+        "sha256": "1755646867c36ecb391776deaa0b557a76d3badf20c142de7282630c34b20440",
+        "dest": "cargo/vendor/rusty-chromaprint-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"023a224821c3208db13134f398c2d92ed81267ef4f65ac8dff670c00b829faac\", \"files\": {}}",
-        "dest": "cargo/vendor/rusty-chromaprint-0.1.3",
+        "contents": "{\"package\": \"1755646867c36ecb391776deaa0b557a76d3badf20c142de7282630c34b20440\", \"files\": {}}",
+        "dest": "cargo/vendor/rusty-chromaprint-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ryu/ryu-1.0.15.crate",
-        "sha256": "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741",
-        "dest": "cargo/vendor/ryu-1.0.15"
+        "url": "https://static.crates.io/crates/rustybuzz/rustybuzz-0.11.0.crate",
+        "sha256": "2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa",
+        "dest": "cargo/vendor/rustybuzz-0.11.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741\", \"files\": {}}",
-        "dest": "cargo/vendor/ryu-1.0.15",
+        "contents": "{\"package\": \"2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa\", \"files\": {}}",
+        "dest": "cargo/vendor/rustybuzz-0.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustybuzz/rustybuzz-0.12.1.crate",
+        "sha256": "f0ae5692c5beaad6a9e22830deeed7874eae8a4e3ba4076fb48e12c56856222c",
+        "dest": "cargo/vendor/rustybuzz-0.12.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f0ae5692c5beaad6a9e22830deeed7874eae8a4e3ba4076fb48e12c56856222c\", \"files\": {}}",
+        "dest": "cargo/vendor/rustybuzz-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ryu/ryu-1.0.16.crate",
+        "sha256": "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c",
+        "dest": "cargo/vendor/ryu-1.0.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c\", \"files\": {}}",
+        "dest": "cargo/vendor/ryu-1.0.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3343,6 +6021,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scoped-tls-hkt/scoped-tls-hkt-0.1.4.crate",
+        "sha256": "3ddc765d3410d9f6c6ca071bf0b67f6b01e3ec4595dc3892f02677e75819dddc",
+        "dest": "cargo/vendor/scoped-tls-hkt-0.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3ddc765d3410d9f6c6ca071bf0b67f6b01e3ec4595dc3892f02677e75819dddc\", \"files\": {}}",
+        "dest": "cargo/vendor/scoped-tls-hkt-0.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.2.0.crate",
         "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
         "dest": "cargo/vendor/scopeguard-1.2.0"
@@ -3356,79 +6047,118 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/self_cell/self_cell-0.10.2.crate",
-        "sha256": "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af",
-        "dest": "cargo/vendor/self_cell-0.10.2"
+        "url": "https://static.crates.io/crates/sctk-adwaita/sctk-adwaita-0.8.1.crate",
+        "sha256": "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550",
+        "dest": "cargo/vendor/sctk-adwaita-0.8.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af\", \"files\": {}}",
-        "dest": "cargo/vendor/self_cell-0.10.2",
+        "contents": "{\"package\": \"82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550\", \"files\": {}}",
+        "dest": "cargo/vendor/sctk-adwaita-0.8.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/semver/semver-1.0.20.crate",
-        "sha256": "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090",
-        "dest": "cargo/vendor/semver-1.0.20"
+        "url": "https://static.crates.io/crates/self_cell/self_cell-0.10.3.crate",
+        "sha256": "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d",
+        "dest": "cargo/vendor/self_cell-0.10.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090\", \"files\": {}}",
-        "dest": "cargo/vendor/semver-1.0.20",
+        "contents": "{\"package\": \"e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d\", \"files\": {}}",
+        "dest": "cargo/vendor/self_cell-0.10.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde/serde-1.0.189.crate",
-        "sha256": "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537",
-        "dest": "cargo/vendor/serde-1.0.189"
+        "url": "https://static.crates.io/crates/self_cell/self_cell-1.0.3.crate",
+        "sha256": "58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba",
+        "dest": "cargo/vendor/self_cell-1.0.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537\", \"files\": {}}",
-        "dest": "cargo/vendor/serde-1.0.189",
+        "contents": "{\"package\": \"58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba\", \"files\": {}}",
+        "dest": "cargo/vendor/self_cell-1.0.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.189.crate",
-        "sha256": "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5",
-        "dest": "cargo/vendor/serde_derive-1.0.189"
+        "url": "https://static.crates.io/crates/semver/semver-1.0.21.crate",
+        "sha256": "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0",
+        "dest": "cargo/vendor/semver-1.0.21"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_derive-1.0.189",
+        "contents": "{\"package\": \"b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0\", \"files\": {}}",
+        "dest": "cargo/vendor/semver-1.0.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.107.crate",
-        "sha256": "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65",
-        "dest": "cargo/vendor/serde_json-1.0.107"
+        "url": "https://static.crates.io/crates/serde/serde-1.0.196.crate",
+        "sha256": "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32",
+        "dest": "cargo/vendor/serde-1.0.196"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_json-1.0.107",
+        "contents": "{\"package\": \"870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-1.0.196",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.3.crate",
-        "sha256": "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186",
-        "dest": "cargo/vendor/serde_spanned-0.6.3"
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.196.crate",
+        "sha256": "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67",
+        "dest": "cargo/vendor/serde_derive-1.0.196"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_spanned-0.6.3",
+        "contents": "{\"package\": \"33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive-1.0.196",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.113.crate",
+        "sha256": "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79",
+        "dest": "cargo/vendor/serde_json-1.0.113"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.113",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_repr/serde_repr-0.1.18.crate",
+        "sha256": "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb",
+        "dest": "cargo/vendor/serde_repr-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_repr-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.5.crate",
+        "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1",
+        "dest": "cargo/vendor/serde_spanned-0.6.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-0.6.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3486,6 +6216,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/shlex/shlex-1.3.0.crate",
+        "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+        "dest": "cargo/vendor/shlex-1.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64\", \"files\": {}}",
+        "dest": "cargo/vendor/shlex-1.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.1.crate",
+        "sha256": "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/simd-adler32/simd-adler32-0.3.7.crate",
         "sha256": "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe",
         "dest": "cargo/vendor/simd-adler32-0.3.7"
@@ -3494,6 +6250,58 @@
         "type": "inline",
         "contents": "{\"package\": \"d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe\", \"files\": {}}",
         "dest": "cargo/vendor/simd-adler32-0.3.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simplecss/simplecss-0.2.1.crate",
+        "sha256": "a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d",
+        "dest": "cargo/vendor/simplecss-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d\", \"files\": {}}",
+        "dest": "cargo/vendor/simplecss-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/siphasher/siphasher-0.3.11.crate",
+        "sha256": "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d",
+        "dest": "cargo/vendor/siphasher-0.3.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d\", \"files\": {}}",
+        "dest": "cargo/vendor/siphasher-0.3.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/skia-bindings/skia-bindings-0.70.0.crate",
+        "sha256": "4bc61a106126a429bb4775ce5fbe23b2bcaa74d1a9c484997f4700de31480b44",
+        "dest": "cargo/vendor/skia-bindings-0.70.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4bc61a106126a429bb4775ce5fbe23b2bcaa74d1a9c484997f4700de31480b44\", \"files\": {}}",
+        "dest": "cargo/vendor/skia-bindings-0.70.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/skia-safe/skia-safe-0.70.0.crate",
+        "sha256": "3201eba92bca1f83864f5c3a48309bcfee7e0590bebd7826e7ab0a49aa24a750",
+        "dest": "cargo/vendor/skia-safe-0.70.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3201eba92bca1f83864f5c3a48309bcfee7e0590bebd7826e7ab0a49aa24a750\", \"files\": {}}",
+        "dest": "cargo/vendor/skia-safe-0.70.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3512,14 +6320,105 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/smallvec/smallvec-1.11.1.crate",
-        "sha256": "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a",
-        "dest": "cargo/vendor/smallvec-1.11.1"
+        "url": "https://static.crates.io/crates/slint/slint-1.4.1.crate",
+        "sha256": "7d51a972e5c6f22793f9b334eeb537121337fbf66ed73e978475fca031fd367a",
+        "dest": "cargo/vendor/slint-1.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a\", \"files\": {}}",
-        "dest": "cargo/vendor/smallvec-1.11.1",
+        "contents": "{\"package\": \"7d51a972e5c6f22793f9b334eeb537121337fbf66ed73e978475fca031fd367a\", \"files\": {}}",
+        "dest": "cargo/vendor/slint-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slint-build/slint-build-1.4.1.crate",
+        "sha256": "ebf98969a520e19ec675435b8c21b883d4a06489947e137bbd30859b50ad0c36",
+        "dest": "cargo/vendor/slint-build-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ebf98969a520e19ec675435b8c21b883d4a06489947e137bbd30859b50ad0c36\", \"files\": {}}",
+        "dest": "cargo/vendor/slint-build-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slint-macros/slint-macros-1.4.1.crate",
+        "sha256": "564b2a25cc34007aa9cd73630394efa972b956fee86538caa5d09808b3ba0c05",
+        "dest": "cargo/vendor/slint-macros-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"564b2a25cc34007aa9cd73630394efa972b956fee86538caa5d09808b3ba0c05\", \"files\": {}}",
+        "dest": "cargo/vendor/slint-macros-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slotmap/slotmap-1.0.7.crate",
+        "sha256": "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a",
+        "dest": "cargo/vendor/slotmap-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a\", \"files\": {}}",
+        "dest": "cargo/vendor/slotmap-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.13.1.crate",
+        "sha256": "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7",
+        "dest": "cargo/vendor/smallvec-1.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-1.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smithay-client-toolkit/smithay-client-toolkit-0.18.1.crate",
+        "sha256": "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a",
+        "dest": "cargo/vendor/smithay-client-toolkit-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a\", \"files\": {}}",
+        "dest": "cargo/vendor/smithay-client-toolkit-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smithay-clipboard/smithay-clipboard-0.7.0.crate",
+        "sha256": "0bb62b280ce5a5cba847669933a0948d00904cf83845c944eae96a4738cea1a6",
+        "dest": "cargo/vendor/smithay-clipboard-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0bb62b280ce5a5cba847669933a0948d00904cf83845c944eae96a4738cea1a6\", \"files\": {}}",
+        "dest": "cargo/vendor/smithay-clipboard-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smol_str/smol_str-0.2.1.crate",
+        "sha256": "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49",
+        "dest": "cargo/vendor/smol_str-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49\", \"files\": {}}",
+        "dest": "cargo/vendor/smol_str-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3551,6 +6450,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/socket2/socket2-0.4.10.crate",
+        "sha256": "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d",
+        "dest": "cargo/vendor/socket2-0.4.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d\", \"files\": {}}",
+        "dest": "cargo/vendor/socket2-0.4.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/softbuffer/softbuffer-0.3.4.crate",
+        "sha256": "f266ce2aa23eaaaa4e758ed44495d505d00fb79f359d46f6c1900cb053123b62",
+        "dest": "cargo/vendor/softbuffer-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f266ce2aa23eaaaa4e758ed44495d505d00fb79f359d46f6c1900cb053123b62\", \"files\": {}}",
+        "dest": "cargo/vendor/softbuffer-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/spin/spin-0.9.8.crate",
         "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
         "dest": "cargo/vendor/spin-0.9.8"
@@ -3559,6 +6484,32 @@
         "type": "inline",
         "contents": "{\"package\": \"6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67\", \"files\": {}}",
         "dest": "cargo/vendor/spin-0.9.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spin_on/spin_on-0.1.1.crate",
+        "sha256": "076e103ed41b9864aa838287efe5f4e3a7a0362dd00671ae62a212e5e4612da2",
+        "dest": "cargo/vendor/spin_on-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"076e103ed41b9864aa838287efe5f4e3a7a0362dd00671ae62a212e5e4612da2\", \"files\": {}}",
+        "dest": "cargo/vendor/spin_on-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/stable_deref_trait/stable_deref_trait-1.2.0.crate",
+        "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3\", \"files\": {}}",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3577,6 +6528,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/static_assertions/static_assertions-1.1.0.crate",
+        "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
+        "dest": "cargo/vendor/static_assertions-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f\", \"files\": {}}",
+        "dest": "cargo/vendor/static_assertions-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/strength_reduce/strength_reduce-0.2.4.crate",
         "sha256": "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82",
         "dest": "cargo/vendor/strength_reduce-0.2.4"
@@ -3585,6 +6549,19 @@
         "type": "inline",
         "contents": "{\"package\": \"fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82\", \"files\": {}}",
         "dest": "cargo/vendor/strength_reduce-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strict-num/strict-num-0.1.1.crate",
+        "sha256": "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731",
+        "dest": "cargo/vendor/strict-num-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731\", \"files\": {}}",
+        "dest": "cargo/vendor/strict-num-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3616,6 +6593,45 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strsim/strsim-0.11.0.crate",
+        "sha256": "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01",
+        "dest": "cargo/vendor/strsim-0.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01\", \"files\": {}}",
+        "dest": "cargo/vendor/strsim-0.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strum/strum-0.26.1.crate",
+        "sha256": "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f",
+        "dest": "cargo/vendor/strum-0.26.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f\", \"files\": {}}",
+        "dest": "cargo/vendor/strum-0.26.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strum_macros/strum_macros-0.26.1.crate",
+        "sha256": "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18",
+        "dest": "cargo/vendor/strum_macros-0.26.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18\", \"files\": {}}",
+        "dest": "cargo/vendor/strum_macros-0.26.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/subtle/subtle-2.5.0.crate",
         "sha256": "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc",
         "dest": "cargo/vendor/subtle-2.5.0"
@@ -3624,6 +6640,19 @@
         "type": "inline",
         "contents": "{\"package\": \"81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc\", \"files\": {}}",
         "dest": "cargo/vendor/subtle-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/svgtypes/svgtypes-0.13.0.crate",
+        "sha256": "6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70",
+        "dest": "cargo/vendor/svgtypes-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70\", \"files\": {}}",
+        "dest": "cargo/vendor/svgtypes-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3837,92 +6866,118 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/syn/syn-2.0.38.crate",
-        "sha256": "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b",
-        "dest": "cargo/vendor/syn-2.0.38"
+        "url": "https://static.crates.io/crates/syn/syn-2.0.49.crate",
+        "sha256": "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496",
+        "dest": "cargo/vendor/syn-2.0.49"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b\", \"files\": {}}",
-        "dest": "cargo/vendor/syn-2.0.38",
+        "contents": "{\"package\": \"915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.49",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/system-deps/system-deps-6.1.2.crate",
-        "sha256": "94af52f9402f94aac4948a2518b43359be8d9ce6cd9efc1c4de3b2f7b7e897d6",
-        "dest": "cargo/vendor/system-deps-6.1.2"
+        "url": "https://static.crates.io/crates/system-deps/system-deps-6.2.0.crate",
+        "sha256": "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331",
+        "dest": "cargo/vendor/system-deps-6.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"94af52f9402f94aac4948a2518b43359be8d9ce6cd9efc1c4de3b2f7b7e897d6\", \"files\": {}}",
-        "dest": "cargo/vendor/system-deps-6.1.2",
+        "contents": "{\"package\": \"2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331\", \"files\": {}}",
+        "dest": "cargo/vendor/system-deps-6.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.11.crate",
-        "sha256": "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a",
-        "dest": "cargo/vendor/target-lexicon-0.12.11"
+        "url": "https://static.crates.io/crates/tar/tar-0.4.40.crate",
+        "sha256": "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb",
+        "dest": "cargo/vendor/tar-0.4.40"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a\", \"files\": {}}",
-        "dest": "cargo/vendor/target-lexicon-0.12.11",
+        "contents": "{\"package\": \"b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb\", \"files\": {}}",
+        "dest": "cargo/vendor/tar-0.4.40",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tempfile/tempfile-3.8.0.crate",
-        "sha256": "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef",
-        "dest": "cargo/vendor/tempfile-3.8.0"
+        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.13.crate",
+        "sha256": "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae",
+        "dest": "cargo/vendor/target-lexicon-0.12.13"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef\", \"files\": {}}",
-        "dest": "cargo/vendor/tempfile-3.8.0",
+        "contents": "{\"package\": \"69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae\", \"files\": {}}",
+        "dest": "cargo/vendor/target-lexicon-0.12.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/termcolor/termcolor-1.3.0.crate",
-        "sha256": "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64",
-        "dest": "cargo/vendor/termcolor-1.3.0"
+        "url": "https://static.crates.io/crates/tempfile/tempfile-3.10.0.crate",
+        "sha256": "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67",
+        "dest": "cargo/vendor/tempfile-3.10.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64\", \"files\": {}}",
-        "dest": "cargo/vendor/termcolor-1.3.0",
+        "contents": "{\"package\": \"a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67\", \"files\": {}}",
+        "dest": "cargo/vendor/tempfile-3.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.49.crate",
-        "sha256": "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4",
-        "dest": "cargo/vendor/thiserror-1.0.49"
+        "url": "https://static.crates.io/crates/termcolor/termcolor-1.4.1.crate",
+        "sha256": "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755",
+        "dest": "cargo/vendor/termcolor-1.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-1.0.49",
+        "contents": "{\"package\": \"06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755\", \"files\": {}}",
+        "dest": "cargo/vendor/termcolor-1.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.49.crate",
-        "sha256": "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc",
-        "dest": "cargo/vendor/thiserror-impl-1.0.49"
+        "url": "https://static.crates.io/crates/text-size/text-size-1.1.1.crate",
+        "sha256": "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233",
+        "dest": "cargo/vendor/text-size-1.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-impl-1.0.49",
+        "contents": "{\"package\": \"f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233\", \"files\": {}}",
+        "dest": "cargo/vendor/text-size-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.57.crate",
+        "sha256": "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b",
+        "dest": "cargo/vendor/thiserror-1.0.57"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-1.0.57",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.57.crate",
+        "sha256": "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81",
+        "dest": "cargo/vendor/thiserror-impl-1.0.57"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-1.0.57",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3941,27 +6996,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tiff/tiff-0.9.0.crate",
-        "sha256": "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211",
-        "dest": "cargo/vendor/tiff-0.9.0"
+        "url": "https://static.crates.io/crates/tiff/tiff-0.9.1.crate",
+        "sha256": "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e",
+        "dest": "cargo/vendor/tiff-0.9.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211\", \"files\": {}}",
-        "dest": "cargo/vendor/tiff-0.9.0",
+        "contents": "{\"package\": \"ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e\", \"files\": {}}",
+        "dest": "cargo/vendor/tiff-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/time/time-0.3.30.crate",
-        "sha256": "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5",
-        "dest": "cargo/vendor/time-0.3.30"
+        "url": "https://static.crates.io/crates/time/time-0.3.34.crate",
+        "sha256": "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749",
+        "dest": "cargo/vendor/time-0.3.34"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5\", \"files\": {}}",
-        "dest": "cargo/vendor/time-0.3.30",
+        "contents": "{\"package\": \"c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749\", \"files\": {}}",
+        "dest": "cargo/vendor/time-0.3.34",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3980,27 +7035,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.15.crate",
-        "sha256": "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20",
-        "dest": "cargo/vendor/time-macros-0.2.15"
+        "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.17.crate",
+        "sha256": "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774",
+        "dest": "cargo/vendor/time-macros-0.2.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20\", \"files\": {}}",
-        "dest": "cargo/vendor/time-macros-0.2.15",
+        "contents": "{\"package\": \"7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774\", \"files\": {}}",
+        "dest": "cargo/vendor/time-macros-0.2.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tinystr/tinystr-0.7.4.crate",
-        "sha256": "d5d0e245e80bdc9b4e5356fc45a72184abbc3861992603f515270e9340f5a219",
-        "dest": "cargo/vendor/tinystr-0.7.4"
+        "url": "https://static.crates.io/crates/tiny-skia/tiny-skia-0.11.4.crate",
+        "sha256": "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab",
+        "dest": "cargo/vendor/tiny-skia-0.11.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d5d0e245e80bdc9b4e5356fc45a72184abbc3861992603f515270e9340f5a219\", \"files\": {}}",
-        "dest": "cargo/vendor/tinystr-0.7.4",
+        "contents": "{\"package\": \"83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab\", \"files\": {}}",
+        "dest": "cargo/vendor/tiny-skia-0.11.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tiny-skia-path/tiny-skia-path-0.11.4.crate",
+        "sha256": "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93",
+        "dest": "cargo/vendor/tiny-skia-path-0.11.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93\", \"files\": {}}",
+        "dest": "cargo/vendor/tiny-skia-path-0.11.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tiny-xlib/tiny-xlib-0.2.2.crate",
+        "sha256": "d4098d49269baa034a8d1eae9bd63e9fa532148d772121dace3bcd6a6c98eb6d",
+        "dest": "cargo/vendor/tiny-xlib-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d4098d49269baa034a8d1eae9bd63e9fa532148d772121dace3bcd6a6c98eb6d\", \"files\": {}}",
+        "dest": "cargo/vendor/tiny-xlib-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinystr/tinystr-0.7.5.crate",
+        "sha256": "83c02bf3c538ab32ba913408224323915f4ef9a6d61c0e85d493f355921c0ece",
+        "dest": "cargo/vendor/tinystr-0.7.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"83c02bf3c538ab32ba913408224323915f4ef9a6d61c0e85d493f355921c0ece\", \"files\": {}}",
+        "dest": "cargo/vendor/tinystr-0.7.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4045,27 +7139,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml/toml-0.8.2.crate",
-        "sha256": "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d",
-        "dest": "cargo/vendor/toml-0.8.2"
+        "url": "https://static.crates.io/crates/toml/toml-0.8.10.crate",
+        "sha256": "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290",
+        "dest": "cargo/vendor/toml-0.8.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d\", \"files\": {}}",
-        "dest": "cargo/vendor/toml-0.8.2",
+        "contents": "{\"package\": \"9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.8.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.3.crate",
-        "sha256": "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b",
-        "dest": "cargo/vendor/toml_datetime-0.6.3"
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.5.crate",
+        "sha256": "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1",
+        "dest": "cargo/vendor/toml_datetime-0.6.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_datetime-0.6.3",
+        "contents": "{\"package\": \"3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-0.6.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4084,27 +7178,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.20.2.crate",
-        "sha256": "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338",
-        "dest": "cargo/vendor/toml_edit-0.20.2"
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.21.1.crate",
+        "sha256": "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1",
+        "dest": "cargo/vendor/toml_edit-0.21.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.20.2",
+        "contents": "{\"package\": \"6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.21.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tracing/tracing-0.1.39.crate",
-        "sha256": "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9",
-        "dest": "cargo/vendor/tracing-0.1.39"
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.22.6.crate",
+        "sha256": "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6",
+        "dest": "cargo/vendor/toml_edit-0.22.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9\", \"files\": {}}",
-        "dest": "cargo/vendor/tracing-0.1.39",
+        "contents": "{\"package\": \"2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.22.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing/tracing-0.1.40.crate",
+        "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+        "dest": "cargo/vendor/tracing-0.1.40"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-0.1.40",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4136,27 +7243,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tracing-log/tracing-log-0.1.3.crate",
-        "sha256": "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922",
-        "dest": "cargo/vendor/tracing-log-0.1.3"
+        "url": "https://static.crates.io/crates/tracing-log/tracing-log-0.2.0.crate",
+        "sha256": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
+        "dest": "cargo/vendor/tracing-log-0.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922\", \"files\": {}}",
-        "dest": "cargo/vendor/tracing-log-0.1.3",
+        "contents": "{\"package\": \"ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-log-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tracing-subscriber/tracing-subscriber-0.3.17.crate",
-        "sha256": "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77",
-        "dest": "cargo/vendor/tracing-subscriber-0.3.17"
+        "url": "https://static.crates.io/crates/tracing-subscriber/tracing-subscriber-0.3.18.crate",
+        "sha256": "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b",
+        "dest": "cargo/vendor/tracing-subscriber-0.3.18"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77\", \"files\": {}}",
-        "dest": "cargo/vendor/tracing-subscriber-0.3.17",
+        "contents": "{\"package\": \"ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-subscriber-0.3.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4175,14 +7282,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/trash/trash-3.1.0.crate",
-        "sha256": "f7b23f2b0cf93f537bbe90cbb59ea9176cc8ce9b010a36dcd5b726facd82825e",
-        "dest": "cargo/vendor/trash-3.1.0"
+        "url": "https://static.crates.io/crates/trash/trash-3.3.1.crate",
+        "sha256": "c658458d46d9d5a153a3b5cdd88d8579ad50d4fb85d53961e4526c8fc7c55a57",
+        "dest": "cargo/vendor/trash-3.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f7b23f2b0cf93f537bbe90cbb59ea9176cc8ce9b010a36dcd5b726facd82825e\", \"files\": {}}",
-        "dest": "cargo/vendor/trash-3.1.0",
+        "contents": "{\"package\": \"c658458d46d9d5a153a3b5cdd88d8579ad50d4fb85d53961e4526c8fc7c55a57\", \"files\": {}}",
+        "dest": "cargo/vendor/trash-3.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4196,6 +7303,32 @@
         "type": "inline",
         "contents": "{\"package\": \"622b09ce2fe2df4618636fb92176d205662f59803f39e70d1c333393082de96c\", \"files\": {}}",
         "dest": "cargo/vendor/triple_accel-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.20.0.crate",
+        "sha256": "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4",
+        "dest": "cargo/vendor/ttf-parser-0.20.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4\", \"files\": {}}",
+        "dest": "cargo/vendor/ttf-parser-0.20.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tuple/tuple-0.5.2.crate",
+        "sha256": "9bb9f6bd73479481158ba8ee3edf17aca93354623d13f02e96a2014fdbc1c37e",
+        "dest": "cargo/vendor/tuple-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9bb9f6bd73479481158ba8ee3edf17aca93354623d13f02e96a2014fdbc1c37e\", \"files\": {}}",
+        "dest": "cargo/vendor/tuple-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4240,27 +7373,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unic-langid/unic-langid-0.9.1.crate",
-        "sha256": "398f9ad7239db44fd0f80fe068d12ff22d78354080332a5077dc6f52f14dcf2f",
-        "dest": "cargo/vendor/unic-langid-0.9.1"
+        "url": "https://static.crates.io/crates/udev/udev-0.7.0.crate",
+        "sha256": "4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a",
+        "dest": "cargo/vendor/udev-0.7.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"398f9ad7239db44fd0f80fe068d12ff22d78354080332a5077dc6f52f14dcf2f\", \"files\": {}}",
-        "dest": "cargo/vendor/unic-langid-0.9.1",
+        "contents": "{\"package\": \"4ebdbbd670373442a12fe9ef7aeb53aec4147a5a27a00bbc3ab639f08f48191a\", \"files\": {}}",
+        "dest": "cargo/vendor/udev-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unic-langid-impl/unic-langid-impl-0.9.1.crate",
-        "sha256": "e35bfd2f2b8796545b55d7d3fd3e89a0613f68a0d1c8bc28cb7ff96b411a35ff",
-        "dest": "cargo/vendor/unic-langid-impl-0.9.1"
+        "url": "https://static.crates.io/crates/uds_windows/uds_windows-1.1.0.crate",
+        "sha256": "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9",
+        "dest": "cargo/vendor/uds_windows-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e35bfd2f2b8796545b55d7d3fd3e89a0613f68a0d1c8bc28cb7ff96b411a35ff\", \"files\": {}}",
-        "dest": "cargo/vendor/unic-langid-impl-0.9.1",
+        "contents": "{\"package\": \"89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9\", \"files\": {}}",
+        "dest": "cargo/vendor/uds_windows-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-langid/unic-langid-0.9.4.crate",
+        "sha256": "238722e6d794ed130f91f4ea33e01fcff4f188d92337a21297892521c72df516",
+        "dest": "cargo/vendor/unic-langid-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"238722e6d794ed130f91f4ea33e01fcff4f188d92337a21297892521c72df516\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-langid-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-langid-impl/unic-langid-impl-0.9.4.crate",
+        "sha256": "4bd55a2063fdea4ef1f8633243a7b0524cbeef1905ae04c31a1c9b9775c55bc6",
+        "dest": "cargo/vendor/unic-langid-impl-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4bd55a2063fdea4ef1f8633243a7b0524cbeef1905ae04c31a1c9b9775c55bc6\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-langid-impl-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4279,14 +7438,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.13.crate",
-        "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
-        "dest": "cargo/vendor/unicode-bidi-0.3.13"
+        "url": "https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.15.crate",
+        "sha256": "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75",
+        "dest": "cargo/vendor/unicode-bidi-0.3.15"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-bidi-0.3.13",
+        "contents": "{\"package\": \"08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-bidi-0.3.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-bidi-mirroring/unicode-bidi-mirroring-0.1.0.crate",
+        "sha256": "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694",
+        "dest": "cargo/vendor/unicode-bidi-mirroring-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-bidi-mirroring-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-ccc/unicode-ccc-0.1.2.crate",
+        "sha256": "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1",
+        "dest": "cargo/vendor/unicode-ccc-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ccc-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4305,6 +7490,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-linebreak/unicode-linebreak-0.1.5.crate",
+        "sha256": "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f",
+        "dest": "cargo/vendor/unicode-linebreak-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-linebreak-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.22.crate",
         "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
         "dest": "cargo/vendor/unicode-normalization-0.1.22"
@@ -4318,14 +7516,144 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/url/url-2.4.1.crate",
-        "sha256": "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5",
-        "dest": "cargo/vendor/url-2.4.1"
+        "url": "https://static.crates.io/crates/unicode-properties/unicode-properties-0.1.1.crate",
+        "sha256": "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291",
+        "dest": "cargo/vendor/unicode-properties-0.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5\", \"files\": {}}",
-        "dest": "cargo/vendor/url-2.4.1",
+        "contents": "{\"package\": \"e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-properties-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-script/unicode-script-0.5.5.crate",
+        "sha256": "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc",
+        "dest": "cargo/vendor/unicode-script-0.5.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-script-0.5.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.11.0.crate",
+        "sha256": "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202",
+        "dest": "cargo/vendor/unicode-segmentation-1.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-segmentation-1.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-vo/unicode-vo-0.1.0.crate",
+        "sha256": "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94",
+        "dest": "cargo/vendor/unicode-vo-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-vo-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.1.11.crate",
+        "sha256": "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85",
+        "dest": "cargo/vendor/unicode-width-0.1.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-width-0.1.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/url/url-2.5.0.crate",
+        "sha256": "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633",
+        "dest": "cargo/vendor/url-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633\", \"files\": {}}",
+        "dest": "cargo/vendor/url-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/urlencoding/urlencoding-2.1.3.crate",
+        "sha256": "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da",
+        "dest": "cargo/vendor/urlencoding-2.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da\", \"files\": {}}",
+        "dest": "cargo/vendor/urlencoding-2.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/usvg/usvg-0.38.0.crate",
+        "sha256": "377f62b4a3c173de8654c1aa80ab1dac1154e6f13a779a9943e53780120d1625",
+        "dest": "cargo/vendor/usvg-0.38.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"377f62b4a3c173de8654c1aa80ab1dac1154e6f13a779a9943e53780120d1625\", \"files\": {}}",
+        "dest": "cargo/vendor/usvg-0.38.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/usvg-parser/usvg-parser-0.38.0.crate",
+        "sha256": "351a05e6f2023d6b4e946f734240a3927aefdcf930d7d42587a2c8a8869814b0",
+        "dest": "cargo/vendor/usvg-parser-0.38.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"351a05e6f2023d6b4e946f734240a3927aefdcf930d7d42587a2c8a8869814b0\", \"files\": {}}",
+        "dest": "cargo/vendor/usvg-parser-0.38.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/usvg-text-layout/usvg-text-layout-0.38.0.crate",
+        "sha256": "8c41888b9d5cf431fe852eaf9d047bbde83251b98f1749c2f08b1071e6db46e2",
+        "dest": "cargo/vendor/usvg-text-layout-0.38.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8c41888b9d5cf431fe852eaf9d047bbde83251b98f1749c2f08b1071e6db46e2\", \"files\": {}}",
+        "dest": "cargo/vendor/usvg-text-layout-0.38.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/usvg-tree/usvg-tree-0.38.0.crate",
+        "sha256": "18863e0404ed153d6e56362c5b1146db9f4f262a3244e3cf2dbe7d8a85909f05",
+        "dest": "cargo/vendor/usvg-tree-0.38.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"18863e0404ed153d6e56362c5b1146db9f4f262a3244e3cf2dbe7d8a85909f05\", \"files\": {}}",
+        "dest": "cargo/vendor/usvg-tree-0.38.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4344,14 +7672,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/uuid/uuid-1.4.1.crate",
-        "sha256": "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d",
-        "dest": "cargo/vendor/uuid-1.4.1"
+        "url": "https://static.crates.io/crates/uuid/uuid-1.7.0.crate",
+        "sha256": "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a",
+        "dest": "cargo/vendor/uuid-1.7.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d\", \"files\": {}}",
-        "dest": "cargo/vendor/uuid-1.4.1",
+        "contents": "{\"package\": \"f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a\", \"files\": {}}",
+        "dest": "cargo/vendor/uuid-1.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4409,6 +7737,71 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vk-parse/vk-parse-0.12.0.crate",
+        "sha256": "81086c28be67a8759cd80cbb3c8f7b520e0874605fc5eb74d5a1c9c2d1878e79",
+        "dest": "cargo/vendor/vk-parse-0.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"81086c28be67a8759cd80cbb3c8f7b520e0874605fc5eb74d5a1c9c2d1878e79\", \"files\": {}}",
+        "dest": "cargo/vendor/vk-parse-0.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vtable/vtable-0.1.11.crate",
+        "sha256": "9f4c7506238561777a1861d3dc3c0001877c475187e7bc4392ea87ebf631fd9c",
+        "dest": "cargo/vendor/vtable-0.1.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f4c7506238561777a1861d3dc3c0001877c475187e7bc4392ea87ebf631fd9c\", \"files\": {}}",
+        "dest": "cargo/vendor/vtable-0.1.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vtable-macro/vtable-macro-0.1.10.crate",
+        "sha256": "6b2b8eecdb8e4284adf5546fc518f048f6dc33e7203dbe36fa93a4add39b31f6",
+        "dest": "cargo/vendor/vtable-macro-0.1.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6b2b8eecdb8e4284adf5546fc518f048f6dc33e7203dbe36fa93a4add39b31f6\", \"files\": {}}",
+        "dest": "cargo/vendor/vtable-macro-0.1.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vulkano/vulkano-0.34.1.crate",
+        "sha256": "70f4278f76307b3c388679234b397b4f90de29cdba53873c26b624ed82653d75",
+        "dest": "cargo/vendor/vulkano-0.34.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"70f4278f76307b3c388679234b397b4f90de29cdba53873c26b624ed82653d75\", \"files\": {}}",
+        "dest": "cargo/vendor/vulkano-0.34.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/waker-fn/waker-fn-1.1.1.crate",
+        "sha256": "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690",
+        "dest": "cargo/vendor/waker-fn-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690\", \"files\": {}}",
+        "dest": "cargo/vendor/waker-fn-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/walkdir/walkdir-2.4.0.crate",
         "sha256": "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee",
         "dest": "cargo/vendor/walkdir-2.4.0"
@@ -4435,79 +7828,261 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.87.crate",
-        "sha256": "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.91.crate",
+        "sha256": "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.91"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.87",
+        "contents": "{\"package\": \"c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.91",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.87.crate",
-        "sha256": "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.91.crate",
+        "sha256": "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.91"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.87",
+        "contents": "{\"package\": \"c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.91",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.87.crate",
-        "sha256": "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.41.crate",
+        "sha256": "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.41"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.87",
+        "contents": "{\"package\": \"877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.41",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.87.crate",
-        "sha256": "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.91.crate",
+        "sha256": "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.91"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.87",
+        "contents": "{\"package\": \"b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.91",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.87.crate",
-        "sha256": "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.87"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.91.crate",
+        "sha256": "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.91"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.87",
+        "contents": "{\"package\": \"642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.91",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/weezl/weezl-0.1.7.crate",
-        "sha256": "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb",
-        "dest": "cargo/vendor/weezl-0.1.7"
+        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.91.crate",
+        "sha256": "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.91"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb\", \"files\": {}}",
-        "dest": "cargo/vendor/weezl-0.1.7",
+        "contents": "{\"package\": \"4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.91",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-backend/wayland-backend-0.3.3.crate",
+        "sha256": "9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40",
+        "dest": "cargo/vendor/wayland-backend-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-backend-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-client/wayland-client-0.31.2.crate",
+        "sha256": "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f",
+        "dest": "cargo/vendor/wayland-client-0.31.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-client-0.31.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-csd-frame/wayland-csd-frame-0.3.0.crate",
+        "sha256": "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e",
+        "dest": "cargo/vendor/wayland-csd-frame-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-csd-frame-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-cursor/wayland-cursor-0.31.1.crate",
+        "sha256": "71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba",
+        "dest": "cargo/vendor/wayland-cursor-0.31.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-cursor-0.31.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-protocols/wayland-protocols-0.31.2.crate",
+        "sha256": "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4",
+        "dest": "cargo/vendor/wayland-protocols-0.31.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-0.31.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-protocols-plasma/wayland-protocols-plasma-0.2.0.crate",
+        "sha256": "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479",
+        "dest": "cargo/vendor/wayland-protocols-plasma-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-plasma-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-protocols-wlr/wayland-protocols-wlr-0.2.0.crate",
+        "sha256": "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6",
+        "dest": "cargo/vendor/wayland-protocols-wlr-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-wlr-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.31.1.crate",
+        "sha256": "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283",
+        "dest": "cargo/vendor/wayland-scanner-0.31.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-scanner-0.31.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.31.1.crate",
+        "sha256": "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af",
+        "dest": "cargo/vendor/wayland-sys-0.31.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-sys-0.31.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.68.crate",
+        "sha256": "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446",
+        "dest": "cargo/vendor/web-sys-0.3.68"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446\", \"files\": {}}",
+        "dest": "cargo/vendor/web-sys-0.3.68",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-time/web-time-0.2.4.crate",
+        "sha256": "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0",
+        "dest": "cargo/vendor/web-time-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0\", \"files\": {}}",
+        "dest": "cargo/vendor/web-time-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-time/web-time-1.0.0.crate",
+        "sha256": "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0",
+        "dest": "cargo/vendor/web-time-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0\", \"files\": {}}",
+        "dest": "cargo/vendor/web-time-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/weezl/weezl-0.1.8.crate",
+        "sha256": "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082",
+        "dest": "cargo/vendor/weezl-0.1.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082\", \"files\": {}}",
+        "dest": "cargo/vendor/weezl-0.1.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/which/which-4.4.2.crate",
+        "sha256": "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7",
+        "dest": "cargo/vendor/which-4.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7\", \"files\": {}}",
+        "dest": "cargo/vendor/which-4.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4552,6 +8127,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-wsapoll/winapi-wsapoll-0.1.1.crate",
+        "sha256": "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e",
+        "dest": "cargo/vendor/winapi-wsapoll-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-wsapoll-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
         "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
         "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
@@ -4591,6 +8179,45 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows/windows-0.52.0.crate",
+        "sha256": "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be",
+        "dest": "cargo/vendor/windows-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.52.0.crate",
+        "sha256": "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9",
+        "dest": "cargo/vendor/windows-core-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.45.0.crate",
+        "sha256": "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0",
+        "dest": "cargo/vendor/windows-sys-0.45.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.45.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.48.0.crate",
         "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
         "dest": "cargo/vendor/windows-sys-0.48.0"
@@ -4599,6 +8226,19 @@
         "type": "inline",
         "contents": "{\"package\": \"677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9\", \"files\": {}}",
         "dest": "cargo/vendor/windows-sys-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.52.0.crate",
+        "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+        "dest": "cargo/vendor/windows-sys-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.52.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4630,6 +8270,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.0.crate",
+        "sha256": "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd",
+        "dest": "cargo/vendor/windows-targets-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.42.2.crate",
         "sha256": "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8",
         "dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2"
@@ -4651,6 +8304,19 @@
         "type": "inline",
         "contents": "{\"package\": \"2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8\", \"files\": {}}",
         "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.0.crate",
+        "sha256": "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4682,6 +8348,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.0.crate",
+        "sha256": "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.42.2.crate",
         "sha256": "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f",
         "dest": "cargo/vendor/windows_i686_gnu-0.42.2"
@@ -4703,6 +8382,19 @@
         "type": "inline",
         "contents": "{\"package\": \"a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e\", \"files\": {}}",
         "dest": "cargo/vendor/windows_i686_gnu-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.0.crate",
+        "sha256": "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4734,6 +8426,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.0.crate",
+        "sha256": "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.42.2.crate",
         "sha256": "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36",
         "dest": "cargo/vendor/windows_x86_64_gnu-0.42.2"
@@ -4755,6 +8460,19 @@
         "type": "inline",
         "contents": "{\"package\": \"53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e\", \"files\": {}}",
         "dest": "cargo/vendor/windows_x86_64_gnu-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.0.crate",
+        "sha256": "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4786,6 +8504,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.0.crate",
+        "sha256": "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.42.2.crate",
         "sha256": "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0",
         "dest": "cargo/vendor/windows_x86_64_msvc-0.42.2"
@@ -4812,27 +8543,261 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-0.5.17.crate",
-        "sha256": "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c",
-        "dest": "cargo/vendor/winnow-0.5.17"
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.0.crate",
+        "sha256": "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c\", \"files\": {}}",
-        "dest": "cargo/vendor/winnow-0.5.17",
+        "contents": "{\"package\": \"dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xxhash-rust/xxhash-rust-0.8.7.crate",
-        "sha256": "9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b",
-        "dest": "cargo/vendor/xxhash-rust-0.8.7"
+        "url": "https://static.crates.io/crates/winit/winit-0.29.10.crate",
+        "sha256": "4c824f11941eeae66ec71111cc2674373c772f482b58939bb4066b642aa2ffcf",
+        "dest": "cargo/vendor/winit-0.29.10"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9828b178da53440fa9c766a3d2f73f7cf5d0ac1fe3980c1e5018d899fd19e07b\", \"files\": {}}",
-        "dest": "cargo/vendor/xxhash-rust-0.8.7",
+        "contents": "{\"package\": \"4c824f11941eeae66ec71111cc2674373c772f482b58939bb4066b642aa2ffcf\", \"files\": {}}",
+        "dest": "cargo/vendor/winit-0.29.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.5.40.crate",
+        "sha256": "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876",
+        "dest": "cargo/vendor/winnow-0.5.40"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.5.40",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.6.1.crate",
+        "sha256": "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401",
+        "dest": "cargo/vendor/winnow-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wio/wio-0.2.2.crate",
+        "sha256": "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5",
+        "dest": "cargo/vendor/wio-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5\", \"files\": {}}",
+        "dest": "cargo/vendor/wio-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11-clipboard/x11-clipboard-0.9.1.crate",
+        "sha256": "613c2be3e772af2bbb57c5a94413675f5ec668bac00a71ada2ced28c420ef087",
+        "dest": "cargo/vendor/x11-clipboard-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"613c2be3e772af2bbb57c5a94413675f5ec668bac00a71ada2ced28c420ef087\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-clipboard-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11-dl/x11-dl-2.21.0.crate",
+        "sha256": "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f",
+        "dest": "cargo/vendor/x11-dl-2.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-dl-2.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb/x11rb-0.12.0.crate",
+        "sha256": "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a",
+        "dest": "cargo/vendor/x11rb-0.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-0.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb/x11rb-0.13.0.crate",
+        "sha256": "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a",
+        "dest": "cargo/vendor/x11rb-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.12.0.crate",
+        "sha256": "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc",
+        "dest": "cargo/vendor/x11rb-protocol-0.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-protocol-0.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.13.0.crate",
+        "sha256": "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34",
+        "dest": "cargo/vendor/x11rb-protocol-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-protocol-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xattr/xattr-1.3.1.crate",
+        "sha256": "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f",
+        "dest": "cargo/vendor/xattr-1.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f\", \"files\": {}}",
+        "dest": "cargo/vendor/xattr-1.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xcursor/xcursor-0.3.5.crate",
+        "sha256": "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911",
+        "dest": "cargo/vendor/xcursor-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911\", \"files\": {}}",
+        "dest": "cargo/vendor/xcursor-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xdg-home/xdg-home-1.1.0.crate",
+        "sha256": "21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e",
+        "dest": "cargo/vendor/xdg-home-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e\", \"files\": {}}",
+        "dest": "cargo/vendor/xdg-home-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xkbcommon/xkbcommon-0.7.0.crate",
+        "sha256": "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e",
+        "dest": "cargo/vendor/xkbcommon-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e\", \"files\": {}}",
+        "dest": "cargo/vendor/xkbcommon-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xkbcommon-dl/xkbcommon-dl-0.4.2.crate",
+        "sha256": "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5",
+        "dest": "cargo/vendor/xkbcommon-dl-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5\", \"files\": {}}",
+        "dest": "cargo/vendor/xkbcommon-dl-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xkeysym/xkeysym-0.2.0.crate",
+        "sha256": "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621",
+        "dest": "cargo/vendor/xkeysym-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621\", \"files\": {}}",
+        "dest": "cargo/vendor/xkeysym-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.19.crate",
+        "sha256": "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a",
+        "dest": "cargo/vendor/xml-rs-0.8.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a\", \"files\": {}}",
+        "dest": "cargo/vendor/xml-rs-0.8.19",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xmlwriter/xmlwriter-0.1.0.crate",
+        "sha256": "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9",
+        "dest": "cargo/vendor/xmlwriter-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9\", \"files\": {}}",
+        "dest": "cargo/vendor/xmlwriter-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xxhash-rust/xxhash-rust-0.8.10.crate",
+        "sha256": "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03",
+        "dest": "cargo/vendor/xxhash-rust-0.8.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03\", \"files\": {}}",
+        "dest": "cargo/vendor/xxhash-rust-0.8.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4846,6 +8811,71 @@
         "type": "inline",
         "contents": "{\"package\": \"56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85\", \"files\": {}}",
         "dest": "cargo/vendor/yaml-rust-0.4.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus/zbus-3.15.0.crate",
+        "sha256": "c45d06ae3b0f9ba1fb2671268b975557d8f5a84bb5ec6e43964f87e763d8bca8",
+        "dest": "cargo/vendor/zbus-3.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c45d06ae3b0f9ba1fb2671268b975557d8f5a84bb5ec6e43964f87e763d8bca8\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus-3.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-3.15.0.crate",
+        "sha256": "b4a1ba45ed0ad344b85a2bb5a1fe9830aed23d67812ea39a586e7d0136439c7d",
+        "dest": "cargo/vendor/zbus_macros-3.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b4a1ba45ed0ad344b85a2bb5a1fe9830aed23d67812ea39a586e7d0136439c7d\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_macros-3.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus_names/zbus_names-2.6.0.crate",
+        "sha256": "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9",
+        "dest": "cargo/vendor/zbus_names-2.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_names-2.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.7.32.crate",
+        "sha256": "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be",
+        "dest": "cargo/vendor/zerocopy-0.7.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-0.7.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.7.32.crate",
+        "sha256": "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6",
+        "dest": "cargo/vendor/zerocopy-derive-0.7.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-derive-0.7.32",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4872,6 +8902,45 @@
         "type": "inline",
         "contents": "{\"package\": \"73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02\", \"files\": {}}",
         "dest": "cargo/vendor/zune-inflate-0.2.54",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant/zvariant-3.15.0.crate",
+        "sha256": "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c",
+        "dest": "cargo/vendor/zvariant-3.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant-3.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-3.15.0.crate",
+        "sha256": "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd",
+        "dest": "cargo/vendor/zvariant_derive-3.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_derive-3.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-1.0.1.crate",
+        "sha256": "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200",
+        "dest": "cargo/vendor/zvariant_utils-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_utils-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.qarmin.czkawka
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -29,6 +29,6 @@ modules:
   sources:
   - cargo-sources.json
   - type: git
-    url: https://github.com/renner0e/czkawka.git
+    url: https://github.com/qarmin/czkawka.git
     # tag: 7.0.0
     commit: 8aa8c1f315ad64e02fd38a744a2b01e30b5746c1

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -29,5 +29,6 @@ modules:
   sources:
   - cargo-sources.json
   - type: git
-    url: https://github.com/qarmin/czkawka.git
-    tag: 7.0.0
+    url: https://github.com/renner0e/czkawka.git
+    # tag: 7.0.0
+    commit: 8aa8c1f315ad64e02fd38a744a2b01e30b5746c1

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -30,4 +30,4 @@ modules:
   - cargo-sources.json
   - type: git
     url: https://github.com/qarmin/czkawka.git
-    tag: 6.1.0
+    tag: 7.0.0

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -30,5 +30,5 @@ modules:
   - cargo-sources.json
   - type: git
     url: https://github.com/qarmin/czkawka.git
-    # tag: 8.0.0
-    commit: 1685fd8ab623cca4e4245a03e0beb661dd48dd53
+    tag: 8.0.0
+    #commit: 1685fd8ab623cca4e4245a03e0beb661dd48dd53

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -30,5 +30,5 @@ modules:
   - cargo-sources.json
   - type: git
     url: https://github.com/qarmin/czkawka.git
-    # tag: 7.0.0
-    commit: 0d31435d93f9e8ea8ff8d54e0cd186358f3b7114
+    # tag: 8.0.0
+    commit: 1685fd8ab623cca4e4245a03e0beb661dd48dd53

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -31,4 +31,4 @@ modules:
   - type: git
     url: https://github.com/qarmin/czkawka.git
     # tag: 7.0.0
-    commit: 8aa8c1f315ad64e02fd38a744a2b01e30b5746c1
+    commit: 0d31435d93f9e8ea8ff8d54e0cd186358f3b7114

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -12,7 +12,6 @@ finish-args:
 - "--filesystem=host"
 - "--device=dri"
 - "--filesystem=~/.var/app"
-- "--filesystem=xdg-config/gtk-4.0:ro"
 build-options:
   append-path: "/usr/lib/sdk/rust-stable/bin"
   env:

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.qarmin.czkawka
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -31,4 +31,4 @@ modules:
   - type: git
     url: https://github.com/qarmin/czkawka.git
     tag: 8.0.0
-    #commit: 1685fd8ab623cca4e4245a03e0beb661dd48dd53
+    # commit: 1685fd8ab623cca4e4245a03e0beb661dd48dd53


### PR DESCRIPTION
Hey all,

I updated the dependencies and runtime and also included the changes from #25 #24 

I'm not a developer. This is how I did it in case I did it wrong.

```
git clone --depth 1 --branch 7.0.0 https://github.com/qarmin/czkawka

git clone https://github.com/flathub/com.github.qarmin.czkawka

cd czkawka/misc/

[enter arch linux container/toolbox]

sudo pacman -S python-aiohttp python-toml

wget https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py

mkdir -p flatpak

python3 flatpak-cargo-generator.py ../Cargo.lock -o flatpak/cargo-sources.json

cp flatpak/cargo-sources.json ../../com.github.qarmin.czkawka

rm flatpak-cargo-generator.py
```

Building takes an awful lot longer than the previous version

![Screenshot_20240430_164100](https://github.com/flathub/com.github.qarmin.czkawka/assets/80410025/1ca7c04d-5fab-4428-a2ce-1eb726482ae0)