### PR TITLE
feat: add deps maintenance script, small readme, gitignore and satisfy the linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder/
+flatpak-builder-tools/
+build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Czkawka Flatpak
+
+[Upstream](https://github.com/qarmin/czkawka)
+
+[Flathub](https://flathub.org/apps/com.github.qarmin.czkawka)
+
+
+# Building from Source
+1. Install [`org.flatpak.Builder`](https://github.com/flathub/org.flatpak.Builder) from Flathub
+2. Clone `https://github.com/flathub/com.github.qarmin.czkawka` (or your fork)
+3. Run `flatpak run org.flatpak.Builder --install --install-deps-from=flathub --force-clean build --user com.github.qarmin.czkawka.yaml`
+4. Run `flatpak run com.github.qarmin.czkawka//master`
+
+# Maintenance
+
+Run `./update-deps.sh` to bump the dependencies in `cargo-sources.json`
+Install Podman beforehand.
+
+## Linting Manifest
+
+```
+flatpak run org.flathub.flatpak-external-data-checker com.github.qarmin.czkawka.yaml
+
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest com.github.qarmin.czkawka.yaml
+```

--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -11,7 +11,6 @@ finish-args:
 - "--socket=wayland"
 - "--filesystem=host"
 - "--device=dri"
-- "--filesystem=~/.var/app"
 build-options:
   append-path: "/usr/lib/sdk/rust-stable/bin"
   env:

--- a/update-deps.sh
+++ b/update-deps.sh
@@ -25,4 +25,4 @@ podman run --rm -it \
   sh -c "mkdir -p /tmp/build/flatpak-builder-tools && \
   curl -o /tmp/build/flatpak-builder-tools/flatpak-cargo-generator.py https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/refs/heads/master/cargo/flatpak-cargo-generator.py && \
   pip install --root-user-action=ignore aiohttp toml && \
-  python3 /tmp/build/flatpak-builder-tools/cargo/flatpak-cargo-generator.py ${LOCK_FILE_DIR}/czkawka-${TARGET_VERSION}/Cargo.lock -o /tmp/build/cargo-sources.json"
+  python3 /tmp/build/flatpak-builder-tools/flatpak-cargo-generator.py ${LOCK_FILE_DIR}/czkawka-${TARGET_VERSION}/Cargo.lock -o /tmp/build/cargo-sources.json"

--- a/update-deps.sh
+++ b/update-deps.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# set this to the git release tag
+TARGET_VERSION="8.0.0"
+
+LOCK_FILE_DIR=$(mktemp -d)
+cleanup() {
+  rm -r "$LOCK_FILE_DIR"
+}
+trap cleanup EXIT
+set -x
+
+curl -s -L "https://github.com/qarmin/czkawka/archive/refs/tags/$TARGET_VERSION.tar.gz" | tar xzf - -C "$LOCK_FILE_DIR"
+
+# Mount current directory as /tmp/build in container
+# download flatpak-cargo-generator and it's dependencies
+# refreshes cargo-sources.json
+podman run --rm -it \
+  -v .:/tmp/build:Z \
+  -v "$LOCK_FILE_DIR:$LOCK_FILE_DIR:Z" \
+  --pull newer \
+  docker.io/library/python:latest \
+  sh -c "mkdir -p /tmp/build/flatpak-builder-tools && \
+  curl -o /tmp/build/flatpak-builder-tools/flatpak-cargo-generator.py https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/refs/heads/master/cargo/flatpak-cargo-generator.py && \
+  pip install --root-user-action=ignore aiohttp toml && \
+  python3 /tmp/build/flatpak-builder-tools/cargo/flatpak-cargo-generator.py ${LOCK_FILE_DIR}/czkawka-${TARGET_VERSION}/Cargo.lock -o /tmp/build/cargo-sources.json"


### PR DESCRIPTION
this makes it way more approachable to maintain

rendered README:
https://github.com/renner0e/com.github.qarmin.czkawka/blob/maintenance-script/README.md

<3 @tulilirockz

EDIT: I removed the permission to `~/.var/app` because we don't need it and it works just fine on that directory with the xdg-desktop-portal

the linter is also happy now
`finish-args-flatpak-appdata-folder-access`
https://docs.flathub.org/docs/for-app-authors/linter#finish-args-flatpak-appdata-folder-access


