### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/com.github.qarmin.czkawka.yaml
+++ b/com.github.qarmin.czkawka.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.qarmin.czkawka
 runtime: org.gnome.Platform
-runtime-version: '47' # Latest version can be obtained here https://flathub.org/apps/org.gnome.Platform
+runtime-version: '48' # Latest version can be obtained here https://flathub.org/apps/org.gnome.Platform
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
tested with `flatpak run --runtime-version=48 com.github.qarmin.czkawka`